### PR TITLE
Ĝisdatigi aŭtorrajtajn menciojn kaj konservi ĉiujn kreditojn

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2016 psychoslave
+Copyright (c) 1994-2016 Lua.org, PUC-Rio
+Copyright (c) 2016-present psychoslave
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PERMISILO.md
+++ b/PERMISILO.md
@@ -1,6 +1,7 @@
 MIT License
 
-Copyright (c) 2016 psychoslave
+Copyright (c) 1994-2016 Lua.org, PUC-Rio
+Copyright (c) 2016-present psychoslave
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/dokumentaro/lua.1
+++ b/dokumentaro/lua.1
@@ -107,5 +107,6 @@ Error messages should be self explanatory.
 .SH AUTHORS
 R. Ierusalimschy,
 L. H. de Figueiredo,
-W. Celes
+W. Celes,
+psychoslave (Lupa adapto)
 .\" EOF

--- a/dokumentaro/luac.1
+++ b/dokumentaro/luac.1
@@ -114,5 +114,6 @@ Error messages should be self explanatory.
 .SH AUTHORS
 R. Ierusalimschy,
 L. H. de Figueiredo,
-W. Celes
+W. Celes,
+psychoslave (Lupa adapto)
 .\" EOF

--- a/fontaro/lua.h
+++ b/fontaro/lua.h
@@ -23,7 +23,9 @@
 
 #define LUA_VERSION	"Lua " LUA_VERSION_MAJOR "." LUA_VERSION_MINOR
 #define LUA_RELEASE	LUA_VERSION "." LUA_VERSION_RELEASE
-#define LUA_COPYRIGHT	LUA_RELEASE "  Copyright (C) 1994-2016 Lua.org, PUC-Rio"
+#define LUPA_COPYRIGHT	"Lupa 0.0.1  Aŭtorrajto (C) ekde 2016 fare de psychoslave"
+#define LUA_COPYRIGHT	LUA_RELEASE "  Copyright (C) 1994-2016 Lua.org, PUC-Rio" "\n" \
+      LUPA_COPYRIGHT
 #define LUA_AUTHORS	"R. Ierusalimschy, L. H. de Figueiredo, W. Celes"
 
 

--- a/fontaro/lua.h
+++ b/fontaro/lua.h
@@ -24,7 +24,7 @@
 #define LUA_VERSION	"Lua " LUA_VERSION_MAJOR "." LUA_VERSION_MINOR
 #define LUA_RELEASE	LUA_VERSION "." LUA_VERSION_RELEASE
 #define LUPA_COPYRIGHT	"Lupa 0.0.1  Aŭtorrajto (C) ekde 2016 fare de psychoslave"
-#define LUA_COPYRIGHT	LUA_RELEASE "  Copyright (C) 1994-2016 Lua.org, PUC-Rio" "\n" \
+#define LUA_COPYRIGHT	LUA_RELEASE "  Aŭtorrajto (C) 1994-2016 Lua.org, PUC-Rio" "\n" \
       LUPA_COPYRIGHT
 #define LUA_AUTHORS	"R. Ierusalimschy, L. H. de Figueiredo, W. Celes"
 


### PR DESCRIPTION
## Resumo
Ĉi tiu MR traktas la peton de issue #1 pri aŭtorrajtaj mencioj, kun eksplicita celo konservi ĉiujn ŝuldajn kreditojn.
## Kio ŝanĝiĝis
- Aldonita dua linio en la versia standardo de `lupe`/`lupkodu`:
  - `Lupa 0.0.1  Aŭtorrajto (C) ekde 2016 fare de psychoslave`
- Konservita la originala Lua-linio sen ŝanĝo:
  - `Lua 5.3.3  Copyright (C) 1994-2016 Lua.org, PUC-Rio`
- Ĝisdatigitaj licencaj kaplinioj en:
  - `LICENSE`
  - `PERMISILO.md`
  por mencii ambaŭ:
  - Lua.org, PUC-Rio (1994-2016)
  - psychoslave (2016-present)
- Ĝisdatigitaj `AUTHORS` sekcioj en:
  - `dokumentaro/lua.1`
  - `dokumentaro/luac.1`
  kun `psychoslave (Lupa adapto)` sen forigi la originalajn Lua-aŭtorojn.
## Kontroloj
- `make -C fontaro lupe lupkodu`
- `./fontaro/lupe -v`
- `./fontaro/lupkodu -v`
- rulado de ĉiuj testdosieroj en `testaro/*.lupa`
Rilatas al: #1