### PR TITLE
[SKIZO] lua53-oficialaj-testoj: URL/mise/medio-ĝisdatigo

### DIFF
--- a/testaro/lua53-oficialaj-testoj.sh
+++ b/testaro/lua53-oficialaj-testoj.sh
@@ -7,12 +7,36 @@ if [ "${LUPA_RUN_LUA53_OFICIALA:-0}" != "1" ]; then
   exit 0
 fi
 
-if ! command -v lua >/dev/null 2>&1; then
-  echo "[SALTITA] lua53-oficialaj-testoj.sh: 'lua' ne disponeblas en PATH"
+UZI_MISE_LUA=0
+if command -v lua >/dev/null 2>&1; then
+  :
+elif command -v mise >/dev/null 2>&1 && mise exec lua@5.3 -- lua -v >/dev/null 2>&1; then
+  UZI_MISE_LUA=1
+  echo "[INFO] Uzas 'mise exec lua@5.3 -- lua' kiel Lua 5.3 provizanton"
+else
+  echo "[SALTITA] lua53-oficialaj-testoj.sh: 'lua' ne disponeblas en PATH kaj 'mise lua@5.3' ne pretas"
   exit 0
 fi
 
-LUA_VER="$(lua -v 2>&1 || true)"
+ruli_lua() {
+  (
+    unset LUA_INIT LUA_INIT_5_3 LUA_PATH LUA_CPATH
+    if [ "$UZI_MISE_LUA" -eq 1 ]; then
+      mise exec lua@5.3 -- lua "$@"
+    else
+      lua "$@"
+    fi
+  )
+}
+
+ruli_lupe() {
+  (
+    unset LUA_INIT LUA_INIT_5_3 LUA_PATH LUA_CPATH
+    "$LUPE_BIN" "$@"
+  )
+}
+
+LUA_VER="$(ruli_lua -v 2>&1 || true)"
 case "$LUA_VER" in
   *"Lua 5.3"*) ;;
   *)
@@ -40,15 +64,15 @@ if [ ! -x "$LUPE_BIN" ]; then
 fi
 
 WORK_DIR="${TMPDIR:-/tmp}/lupa-lua53-oficialaj-testoj"
-ARCHIVE="$WORK_DIR/lua-5.3.6.tar.gz"
-SRC_DIR="$WORK_DIR/lua-5.3.6"
-TEST_DIR="$SRC_DIR/testes"
+LUA_VERSIO="5.3.6"
+ARCHIVE="$WORK_DIR/lua-$LUA_VERSIO.tar.gz"
+TEST_DIR="$WORK_DIR/lua-$LUA_VERSIO/testes"
 mkdir -p "$WORK_DIR"
 
 if [ ! -d "$TEST_DIR" ]; then
-  echo "[INFO] Elŝutante Lua 5.3.6 testaron..."
-  rm -rf "$SRC_DIR"
-  curl -fsSL -o "$ARCHIVE" "https://www.lua.org/ftp/lua-5.3.6.tar.gz"
+  echo "[INFO] Elŝutante Lua $LUA_VERSIO testaron el lua/lua GitHub-arkivo..."
+  rm -rf "$WORK_DIR/lua-$LUA_VERSIO"
+  curl -fsSL -o "$ARCHIVE" "https://github.com/lua/lua/archive/refs/tags/v$LUA_VERSIO.tar.gz"
   tar -xzf "$ARCHIVE" -C "$WORK_DIR"
 fi
 
@@ -61,7 +85,7 @@ LUA_OUT="$WORK_DIR/lua53.out"
 LUPA_OUT="$WORK_DIR/lupa53.out"
 
 echo "[INFO] Rulante oficialajn testojn per Lua 5.3..."
-if (cd "$TEST_DIR" && lua all.lua >"$LUA_OUT" 2>&1); then
+if (cd "$TEST_DIR" && ruli_lua all.lua >"$LUA_OUT" 2>&1); then
   LUA_OK=1
 else
   LUA_OK=0
@@ -74,7 +98,7 @@ if [ "$LUA_OK" -ne 1 ]; then
 fi
 
 echo "[INFO] Rulante oficialajn testojn per Lupa..."
-if (cd "$TEST_DIR" && "$LUPE_BIN" all.lua >"$LUPA_OUT" 2>&1); then
+if (cd "$TEST_DIR" && ruli_lupe all.lua >"$LUPA_OUT" 2>&1); then
   LUPA_OK=1
 else
   LUPA_OK=0


### PR DESCRIPTION
Rilata issue: #20

Ĉi tiu estas **draft PR** por konservi nur la laboron en `testaro/lua53-oficialaj-testoj.sh` dum la nuna blokilo estas diagnozata.

Enhavo:
- subteno por `mise exec lua@5.3 -- lua`
- transiro al testaro el `lua/lua` v5.3.6 (`testes/`)
- purigado de `LUA_INIT`, `LUA_PATH`, `LUA_CPATH` dum ruloj

Noto: la referenca Lua-rulo ankoraŭ paneas en `main.lua` (interaga/prompta parto), do ĉi tio restas skizo ĝis ni havas stabilan reprodukteblan solvon.
