### PR TITLE
Forigi redundan TK_COLON el aliases-tabelo en llex.c

### DIFF
--- a/fontaro/llex.c
+++ b/fontaro/llex.c
@@ -135,7 +135,6 @@ static const struct {
   { "kroĉe",TK_CONCAT }, // ..
   { "krocxe",TK_CONCAT }, //
   { "sin", TK_COLON }, // :
-  { ":", TK_COLON } // :
 };
 
 #define save_and_next(ls) (save(ls, ls->current), next(ls))


### PR DESCRIPTION
Ĉi tiu ŝanĝo foriras la redundan ':' enon el la alianomo-tabelo en `fontaro/llex.c`

## Kialo
La karaktero ':' estas jam traktata direkto en la leksilo-skanado (ĉe linio 632-636 en fontaro/llex.c), do ĝi ne devus esti en la alianomo-tabelo. La  alianomo-tabelo estas por **identigiloj** (vortoj) tradukitaj al operatoroj, ne por karakteroj mem.

La Esperanto-vorto **'sin'** restas en la  alianomo-tabelo kaj funkcias bone, kiel montrite per testoj.

## Testoj
- ✅ Rekonstruo sukcesis
- ✅ sinonimoj-leksilo.lupa testas
- ✅ sinonimoj-bibliotekoj.lupa testas
- ✅ objekto.lupa testas

## Referenco
https://github.com/psychoslave/lupa/issues/5