### PR TITLE
Aldoni cit/malcit/ĉit kun ĥaŭ-eskapo kaj LoTPoCIo-kovrado

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "fontaro/utf8proc"]
+	path = fontaro/utf8proc
+	url = https://github.com/JuliaStrings/utf8proc.git

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Lupa
 
-**Lupa estas Lua 5.3-kongrua lingvaĵo por verki Lua-programojn per Esperanta vortprovizo.**
+**Lupa celas retrokongruecon kun Lua 5.3, sed liveras superaron de ebloj: pli vasta Unikoda subteno kaj nova ĉen-konstruaĵo per la unika `citĉit-ilo`.**
 
 Lupa estas disbranĉiĝo de Lua 5.3.3 kun Esperantaj sinonimoj por ŝlosilvortoj, operatoroj kaj parto de la normaj bibliotekoj.
 

--- a/dokumentaro/esperantaj-sinonimoj.md
+++ b/dokumentaro/esperantaj-sinonimoj.md
@@ -81,7 +81,7 @@ Por la operatoro `~=` (neegala), ni adoptis la neologismon **`zaŭ`** (kaj ĝiaj
 - longĉeno-komenco (`[[`-simile) -> `cit`
 - longĉeno-fino (`]]`-simile) -> `malcit`, `ĉit`
 - en `cit`-ĉeno, laŭvortigi la sekvan signon -> `ĥaŭ`
-- en `cit`-ĉeno, speciale interpreti eskapan komandon -> `ĥaĵ`
+- en `cit`-ĉeno, speciale interpreti eskapan komandon -> `ĥap`
 
 La sintaksanalizilo jam distingas la kuntekstojn de `,` (ekz. disigo de esprimoj, nomlistoj, argumentoj); `tuj` kaj `plie` mapigas al la sama komo-signo.
 
@@ -91,26 +91,26 @@ Por `cit`, la unua sekva **apartigila signo** (blanksigno aŭ ne-litera interpun
 
 `ĥaŭ` en `cit`-ĉeno malaktivigas la sekvan signon por fermila detekto (ekz. `ĥaŭmalcit`, `ĥaŭĉit`, `ĥaŭĥaŭ`). La formo estis elektita ankaŭ ĉar ĝi ne aperas en Tekstaro (0 trafoj), do kolizio-risko estas minimuma.
 
-`cit` **ne** interpretas `\`-sekvencojn (ekz. `cit \n ĉit` redonas laŭvorte `\n`). Tio estas intenca: laŭvortigo (`ĥaŭ`) kaj speciala interpreto (`ĥaĵ`) estas apartaj mekanismoj por minimumigi surprizon.
+`cit` **ne** interpretas `\`-sekvencojn (ekz. `cit \n ĉit` redonas laŭvorte `\n`). Tio estas intenca: laŭvortigo (`ĥaŭ`) kaj speciala interpreto (`ĥap`) estas apartaj mekanismoj por minimumigi surprizon.
 
-`ĥaĵ` estis elektita ĉar ĝi restas leksike parenca al `ĥaŭ` kaj same havas 0 trafojn en Tekstaro; tiel kolizio-risko kun ordinara Esperanto restas minimuma.
+`ĥap` estis elektita ĉar ĝi restas leksike parenca al `ĥaŭ` kaj same havas 0 trafojn en Tekstaro; tiel kolizio-risko kun ordinara Esperanto restas minimuma.
 
-#### `ĥaĵ`: sintakso
+#### `ĥap`: sintakso
 
 Du formoj estas validaj:
 
-- **limigita formo**: `ĥaĵe-<subkomando>-...-`
-  - ekz: `ĥaĵe-n-`, `ĥaĵe-novlinie-`, `ĥaĵe-x-7B-`, `ĥaĵe-u-263A-`
-- **rekta longa formo** (sen `e-`): `ĥaĵ<plurlitera-subkomando>` aŭ `ĥaĵ<plurlitera-subkomando>-<parametro>`
-  - ekz: `ĥaĵspacglute`, `ĥaĵunikodpunkte-263A`, `ĥaĵdeksesume-7B`
+- **limigita formo**: `ĥape-<subkomando>-...-`
+  - ekz: `ĥape-n-`, `ĥape-novlinie-`, `ĥape-x-7B-`, `ĥape-u-263A-`
+- **rekta longa formo** (sen `e-`): `ĥap<plurlitera-subkomando>` aŭ `ĥap<plurlitera-subkomando>-<parametro>`
+  - ekz: `ĥapspacglute`, `ĥapunikodpunkte-263A`, `ĥapdeksesume-7B`
 
 En la limigita formo la fina `-` de la eskapo estas konsumita; la sekva signo jam apartenas al ordinara ĉena enhavo.
 
-Intence, **rekta monoletara** formo estas nevalida: `ĥaĵn`, `ĥaĵx7B`, `ĥaĵz`, `ĥaĵu-263A`, ktp. Tio evitas konfuzon (ekz. kun `hxajx`) kaj devigas pli klarajn formojn.
+Intence, **rekta monoletara** formo estas nevalida: `ĥapn`, `ĥapx7B`, `ĥapz`, `ĥapu-263A`, ktp. Tio evitas konfuzon (ekz. kun `hxapx`) kaj devigas pli klarajn formojn.
 
-Atentu: `cit` ankoraŭ forigas unu apartigilan signon tuj antaŭ `malcit`/`ĉit`. Do se eskapo produktas apartigilan signon (ekz. `{`), necesas aldoni apartan separatoron antaŭ la fermilo por ke la produktita signo restu en la rezulto (ekz. `... ĥaĵe-x-7B- ĉit`).
+Atentu: `cit` ankoraŭ forigas unu apartigilan signon tuj antaŭ `malcit`/`ĉit`. Do se eskapo produktas apartigilan signon (ekz. `{`), necesas aldoni apartan separatoron antaŭ la fermilo por ke la produktita signo restu en la rezulto (ekz. `... ĥape-x-7B- ĉit`).
 
-#### Subkomandoj de `ĥaĵ`
+#### Subkomandoj de `ĥap`
 
 - Sen parametro:
   - `a` / `alarme`
@@ -124,13 +124,13 @@ Atentu: `cit` ankoraŭ forigas unu apartigilan signon tuj antaŭ `malcit`/`ĉit`
   - `\`, `"`, `'` (nur en plena formo: `e-\-`, `e-"-`, `e-'-`)
   - `retrostreko`, `citilo`, `apostrofo` (legeblaj sinonimoj)
 - Kun parametro:
-  - `x` / `deksesume`: du deksesumaj ciferoj (0x00..0xFF), ekz. `ĥaĵe-x-7B-` aŭ `ĥaĵdeksesume-7B`
-  - `u` / `unikodpunkte`: unikoda kodpunkto en deksesuma formo (ĝis `10FFFF`), ekz. `ĥaĵe-u-263A-` aŭ `ĥaĵunikodpunkte-263A`
-  - `dekume`: 1..3 dekumaj ciferoj (0..255), ekz. `ĥaĵe-dekume-123-` aŭ `ĥaĵdekume-123`
+  - `x` / `deksesume`: du deksesumaj ciferoj (0x00..0xFF), ekz. `ĥape-x-7B-` aŭ `ĥapdeksesume-7B`
+  - `u` / `unikodpunkte`: unikoda kodpunkto en deksesuma formo (ĝis `10FFFF`), ekz. `ĥape-u-263A-` aŭ `ĥapunikodpunkte-263A`
+  - `dekume`: 1..3 dekumaj ciferoj (0..255), ekz. `ĥape-dekume-123-` aŭ `ĥapdekume-123`
 
-`ĥaĵe-111-...` estas intence **nevalida**: pura cifera subkomando ne estas akceptata.
+`ĥape-111-...` estas intence **nevalida**: pura cifera subkomando ne estas akceptata.
 
-Neekzistantaj aŭ misformitaj `ĥaĵ`-komandoj liveras eraron `invalid escape sequence`, kongrue kun Lua-stila fiasko por nevalidaj eskapoj.
+Neekzistantaj aŭ misformitaj `ĥap`-komandoj liveras eraron `invalid escape sequence`, kongrue kun Lua-stila fiasko por nevalidaj eskapoj.
 
 ### Kiam `cit` efektive malfermas ĉenon
 

--- a/dokumentaro/esperantaj-sinonimoj.md
+++ b/dokumentaro/esperantaj-sinonimoj.md
@@ -97,29 +97,36 @@ Por `cit`, la unua sekva **apartigila signo** (blanksigno aŭ ne-litera interpun
 
 #### `ĥaĵ`: sintakso
 
-Du formoj ekzistas:
+Du formoj estas validaj:
 
-- **rekta mallonga formo**: `ĥaĵ<komando>` aŭ `ĥaĵ<komando><fiks-larĝa-parametro>`
-  - ekz: `ĥaĵn` (novlinio), `ĥaĵx7B` (`{`)
-- **plena limigita formo**: `ĥaĵe-<subkomando>-...-`
+- **limigita formo**: `ĥaĵe-<subkomando>-...-`
   - ekz: `ĥaĵe-n-`, `ĥaĵe-novlinie-`, `ĥaĵe-x-7B-`, `ĥaĵe-u-263A-`
+- **rekta longa formo** (sen `e-`): `ĥaĵ<plurlitera-subkomando>` aŭ `ĥaĵ<plurlitera-subkomando>-<parametro>`
+  - ekz: `ĥaĵspacglute`, `ĥaĵunikodpunkte-263A`, `ĥaĵdeksesume-7B`
 
-En la plena formo la fina `-` de la eskapo estas konsumita; la sekva signo jam apartenas al ordinara ĉena enhavo.
+En la limigita formo la fina `-` de la eskapo estas konsumita; la sekva signo jam apartenas al ordinara ĉena enhavo.
+
+Intence, **rekta monoletara** formo estas nevalida: `ĥaĵn`, `ĥaĵx7B`, `ĥaĵz`, `ĥaĵu-263A`, ktp. Tio evitas konfuzon (ekz. kun `hxajx`) kaj devigas pli klarajn formojn.
 
 Atentu: `cit` ankoraŭ forigas unu apartigilan signon tuj antaŭ `malcit`/`ĉit`. Do se eskapo produktas apartigilan signon (ekz. `{`), necesas aldoni apartan separatoron antaŭ la fermilo por ke la produktita signo restu en la rezulto (ekz. `... ĥaĵe-x-7B- ĉit`).
 
 #### Subkomandoj de `ĥaĵ`
 
 - Sen parametro:
-  - `a`, `b`, `f`, `n`, `r`, `t`, `v`
-  - `novlinie` (sinonimo de `n`)
+  - `a` / `alarme`
+  - `b` / `retropaŝe`
+  - `f` / `paĝosalte`
+  - `n` / `novlinie`
+  - `r` / `ĉaretrevene`
+  - `t` / `tabe`
+  - `v` / `vertikalatabe`
   - `z`, `spacglute` (englutas sekvan blankspacon/novliniojn en la fonto)
   - `\`, `"`, `'` (nur en plena formo: `e-\-`, `e-"-`, `e-'-`)
   - `retrostreko`, `citilo`, `apostrofo` (legeblaj sinonimoj)
 - Kun parametro:
-  - `x` / `deksesume`: du deksesumaj ciferoj (0x00..0xFF), ekz. `ĥaĵe-x-7B-`
-  - `u` / `unikodpunkte`: unikoda kodpunkto en deksesuma formo (ĝis `10FFFF`), ekz. `ĥaĵe-u-263A-`
-  - `dekume`: 1..3 dekumaj ciferoj (0..255), ekz. `ĥaĵe-dekume-123-`
+  - `x` / `deksesume`: du deksesumaj ciferoj (0x00..0xFF), ekz. `ĥaĵe-x-7B-` aŭ `ĥaĵdeksesume-7B`
+  - `u` / `unikodpunkte`: unikoda kodpunkto en deksesuma formo (ĝis `10FFFF`), ekz. `ĥaĵe-u-263A-` aŭ `ĥaĵunikodpunkte-263A`
+  - `dekume`: 1..3 dekumaj ciferoj (0..255), ekz. `ĥaĵe-dekume-123-` aŭ `ĥaĵdekume-123`
 
 `ĥaĵe-111-...` estas intence **nevalida**: pura cifera subkomando ne estas akceptata.
 

--- a/dokumentaro/esperantaj-sinonimoj.md
+++ b/dokumentaro/esperantaj-sinonimoj.md
@@ -81,6 +81,7 @@ Por la operatoro `~=` (neegala), ni adoptis la neologismon **`zaŭ`** (kaj ĝiaj
 - longĉeno-komenco (`[[`-simile) -> `cit`
 - longĉeno-fino (`]]`-simile) -> `malcit`, `ĉit`
 - en `cit`-ĉeno, laŭvortigi la sekvan signon -> `ĥaŭ`
+- en `cit`-ĉeno, speciale interpreti eskapan komandon -> `ĥaĵ`
 
 La sintaksanalizilo jam distingas la kuntekstojn de `,` (ekz. disigo de esprimoj, nomlistoj, argumentoj); `tuj` kaj `plie` mapigas al la sama komo-signo.
 
@@ -89,6 +90,40 @@ Por `::`, la sinonimo `ho` baziĝas sur la vokativa interjekcio en Esperanto: ĝ
 Por `cit`, la unua sekva **apartigila signo** (blanksigno aŭ ne-litera interpunkcio) estas ignorata, kaj same unu apartigila signo tuj antaŭ `malcit`/`ĉit` ne eniras la rezultan ĉenon. La ĉeno povas transiri plurajn liniojn ĝis `malcit` aŭ `ĉit`, por konduto pli proksima al `[[ ... ]]`.
 
 `ĥaŭ` en `cit`-ĉeno malaktivigas la sekvan signon por fermila detekto (ekz. `ĥaŭmalcit`, `ĥaŭĉit`, `ĥaŭĥaŭ`). La formo estis elektita ankaŭ ĉar ĝi ne aperas en Tekstaro (0 trafoj), do kolizio-risko estas minimuma.
+
+`cit` **ne** interpretas `\`-sekvencojn (ekz. `cit \n ĉit` redonas laŭvorte `\n`). Tio estas intenca: laŭvortigo (`ĥaŭ`) kaj speciala interpreto (`ĥaĵ`) estas apartaj mekanismoj por minimumigi surprizon.
+
+`ĥaĵ` estis elektita ĉar ĝi restas leksike parenca al `ĥaŭ` kaj same havas 0 trafojn en Tekstaro; tiel kolizio-risko kun ordinara Esperanto restas minimuma.
+
+#### `ĥaĵ`: sintakso
+
+Du formoj ekzistas:
+
+- **rekta mallonga formo**: `ĥaĵ<komando>` aŭ `ĥaĵ<komando><fiks-larĝa-parametro>`
+  - ekz: `ĥaĵn` (novlinio), `ĥaĵx7B` (`{`)
+- **plena limigita formo**: `ĥaĵe-<subkomando>-...-`
+  - ekz: `ĥaĵe-n-`, `ĥaĵe-novlinie-`, `ĥaĵe-x-7B-`, `ĥaĵe-u-263A-`
+
+En la plena formo la fina `-` de la eskapo estas konsumita; la sekva signo jam apartenas al ordinara ĉena enhavo.
+
+Atentu: `cit` ankoraŭ forigas unu apartigilan signon tuj antaŭ `malcit`/`ĉit`. Do se eskapo produktas apartigilan signon (ekz. `{`), necesas aldoni apartan separatoron antaŭ la fermilo por ke la produktita signo restu en la rezulto (ekz. `... ĥaĵe-x-7B- ĉit`).
+
+#### Subkomandoj de `ĥaĵ`
+
+- Sen parametro:
+  - `a`, `b`, `f`, `n`, `r`, `t`, `v`
+  - `novlinie` (sinonimo de `n`)
+  - `z`, `spacglute` (englutas sekvan blankspacon/novliniojn en la fonto)
+  - `\`, `"`, `'` (nur en plena formo: `e-\-`, `e-"-`, `e-'-`)
+  - `retrostreko`, `citilo`, `apostrofo` (legeblaj sinonimoj)
+- Kun parametro:
+  - `x` / `deksesume`: du deksesumaj ciferoj (0x00..0xFF), ekz. `ĥaĵe-x-7B-`
+  - `u` / `unikodpunkte`: unikoda kodpunkto en deksesuma formo (ĝis `10FFFF`), ekz. `ĥaĵe-u-263A-`
+  - `dekume`: 1..3 dekumaj ciferoj (0..255), ekz. `ĥaĵe-dekume-123-`
+
+`ĥaĵe-111-...` estas intence **nevalida**: pura cifera subkomando ne estas akceptata.
+
+Neekzistantaj aŭ misformitaj `ĥaĵ`-komandoj liveras eraron `invalid escape sequence`, kongrue kun Lua-stila fiasko por nevalidaj eskapoj.
 
 ### Kiam `cit` efektive malfermas ĉenon
 

--- a/dokumentaro/esperantaj-sinonimoj.md
+++ b/dokumentaro/esperantaj-sinonimoj.md
@@ -89,6 +89,8 @@ Por `::`, la sinonimo `ho` baziĝas sur la vokativa interjekcio en Esperanto: ĝ
 
 Por `cit`, la unua sekva **apartigila signo** (blanksigno aŭ ne-litera interpunkcio) estas ignorata, kaj same unu apartigila signo tuj antaŭ `malcit`/`ĉit` ne eniras la rezultan ĉenon. La ĉeno povas transiri plurajn liniojn ĝis `malcit` aŭ `ĉit`, por konduto pli proksima al `[[ ... ]]`.
 
+Praktika mnemoniko por malplena ĉeno: `cit∅ĉit` (kaj ankaŭ `cit{}ĉit`) redonas `""`. Tio kongruas kun la simbola ideo de malplena aro (`∅` aŭ `{}`), samtempe montrante ke la mekanismo povas engluti unu aŭ du apartigilojn ĉe la limoj.
+
 `ĥaŭ` en `cit`-ĉeno malaktivigas la sekvan signon por fermila detekto (ekz. `ĥaŭmalcit`, `ĥaŭĉit`, `ĥaŭĥaŭ`). La formo estis elektita ankaŭ ĉar ĝi ne aperas en Tekstaro (0 trafoj), do kolizio-risko estas minimuma.
 
 `cit` **ne** interpretas `\`-sekvencojn (ekz. `cit \n ĉit` redonas laŭvorte `\n`). Tio estas intenca: laŭvortigo (`ĥaŭ`) kaj speciala interpreto (`ĥap`) estas apartaj mekanismoj por minimumigi surprizon.

--- a/dokumentaro/esperantaj-sinonimoj.md
+++ b/dokumentaro/esperantaj-sinonimoj.md
@@ -78,10 +78,32 @@ Por la operatoro `~=` (neegala), ni adoptis la neologismon **`zaŭ`** (kaj ĝiaj
 - `=` -> `iĝu`, `igxu`, `iĝe`, `igxe`
 - `;` -> `nu`
 - `,` -> `tuj`, `plie`
+- longĉeno-komenco (`[[`-simile) -> `cit`
+- longĉeno-fino (`]]`-simile) -> `malcit`, `ĉit`
+- en `cit`-ĉeno, laŭvortigi la sekvan signon -> `ĥaŭ`
 
 La sintaksanalizilo jam distingas la kuntekstojn de `,` (ekz. disigo de esprimoj, nomlistoj, argumentoj); `tuj` kaj `plie` mapigas al la sama komo-signo.
 
 Por `::`, la sinonimo `ho` baziĝas sur la vokativa interjekcio en Esperanto: ĝi semantike markas alvokon/alparolon al etikedo-celo (`ho etikedo ho`).
+
+Por `cit`, la unua sekva **apartigila signo** (blanksigno aŭ ne-litera interpunkcio) estas ignorata, kaj same unu apartigila signo tuj antaŭ `malcit`/`ĉit` ne eniras la rezultan ĉenon. La ĉeno povas transiri plurajn liniojn ĝis `malcit` aŭ `ĉit`, por konduto pli proksima al `[[ ... ]]`.
+
+`ĥaŭ` en `cit`-ĉeno malaktivigas la sekvan signon por fermila detekto (ekz. `ĥaŭmalcit`, `ĥaŭĉit`, `ĥaŭĥaŭ`). La formo estis elektita ankaŭ ĉar ĝi ne aperas en Tekstaro (0 trafoj), do kolizio-risko estas minimuma.
+
+### Kiam `cit` efektive malfermas ĉenon
+
+`cit` ŝaltas ĉen-legadon nur kiam ĝi estas legata kiel aparta nomo (`TK_NAME`) kun valoro `cit`.
+
+Praktike tio signifas:
+
+- **Malfermas** kiam la sekva signo ne apartenas al identigilo:
+  - blanksigno (`cit saluton malcit`, `cit\tsaluton malcit`, `cit\n...ĉit`)
+  - interpunkcio/operatoro (`cit,saluton malcit`, `cit^¡saluton!ĉit`, `cit¡saluton!ĉit`, ktp)
+- **Ne malfermas** kiam la sekva signo etendas la saman identigilon:
+  - ASCII litero/cifero/substreko (`citalfa`, `cit1`, `cit_`)
+  - UTF-8 liter-komenco (ekz. `citŝnuro`, `citĉeno`), ĉar tio restas unu identigilo.
+
+Krome, `malcit`/`ĉit` fermas nur ĉe vortlimoj (do internvorta kiel `sinmalciti` aŭ `aĉiti` ne fermas).
 
 ### Klarigoj pri la realigitaj formoj
 
@@ -173,6 +195,8 @@ La rilataj testoj troviĝas en:
 
 - `testaro/sinonimoj-leksilo.lupa`
 - `testaro/sinonimoj-bibliotekoj.lupa`
-- `testaro/lua53-kongruo.lua`
+- `testaro/cit-kazoj.lupa`
+- `testaro/lua53-kongruo.lupa`
+- `testaro/lotpocio-kongruo.sh`
 
 La tria testdosiero provas kondutan kongruon inter Lua 5.3 kaj Lupa por kanona Lua-kodo (sen Lupa-specifaj sinonimoj).

--- a/dokumentaro/ĵargono.md
+++ b/dokumentaro/ĵargono.md
@@ -1,0 +1,15 @@
+# Ĵargono de Lupa
+
+## LoTPoCIo
+
+En Lupa ni preferas **LoTPoCIo** anstataŭ la angla akronimo **REPL**.
+
+- **Lo** = lego
+- **T** = takso
+- **Po** = printo
+- **Ci** = ciklo
+- **I** = interpretilo
+
+La formo celas Esperantan, ludeman terminologion kaj samtempe aludas al “lot-pocio”, en spirito de tradiciaj programlingvaj ŝercoj pri “magia” interaga evoluigo.
+
+Kiam dokumentaro aŭ komentoj mencias interagan komandlinian reĝimon, uzu “LoTPoCIo”.

--- a/fareblaro
+++ b/fareblaro
@@ -78,23 +78,40 @@ plentesti:	vaki
 		exit 1; \
 	fi; \
 	malsukcesoj=0; \
+	sukcesoj=0; \
+	entute=0; \
+	if [ -t 1 ]; then \
+		kolorbone=`printf '\033[32m'`; \
+		kolormise=`printf '\033[31m'`; \
+		kolorinformo=`printf '\033[36m'`; \
+		kolornulo=`printf '\033[0m'`; \
+	else \
+		kolorbone=''; kolormise=''; kolorinformo=''; kolornulo=''; \
+	fi; \
+	tmpeligo=`mktemp -t lupa-test.XXXXXX`; \
+	trap 'rm -f "$$tmpeligo"' EXIT INT TERM; \
 	for dosiero in $(TESTODOSIEROJ); do \
-		echo "-> $$dosiero"; \
+		entute=`expr $$entute + 1`; \
 		case "$$dosiero" in \
 			*.sh) rulkmd="sh \"$$dosiero\"" ;; \
 			*)    rulkmd="./fontaro/lupe \"$$dosiero\"" ;; \
 		esac; \
-		if eval $$rulkmd; then \
-			:; \
+		if eval $$rulkmd >"$$tmpeligo" 2>&1; then \
+			sukcesoj=`expr $$sukcesoj + 1`; \
+			linioj=`wc -l < "$$tmpeligo" | tr -d '[:space:]'`; \
+			printf '%s[BONE]%s %s (eligo: %s linio(j))\n' "$$kolorbone" "$$kolornulo" "$$dosiero" "$$linioj"; \
 		else \
+			linioj=`wc -l < "$$tmpeligo" | tr -d '[:space:]'`; \
+			printf '%s[MISE]%s %s (eligo: %s linio(j))\n' "$$kolormise" "$$kolornulo" "$$dosiero" "$$linioj"; \
+			cat "$$tmpeligo"; \
 			malsukcesoj=`expr $$malsukcesoj + 1`; \
 		fi; \
 	done; \
+	printf '%sResumo:%s %s/%s sukcesis, %s malsukcesis.\n' "$$kolorinformo" "$$kolornulo" "$$sukcesoj" "$$entute" "$$malsukcesoj"; \
 	if [ $$malsukcesoj -gt 0 ]; then \
-		echo "Malsukcesis $$malsukcesoj testo(j)."; \
 		exit 1; \
 	fi; \
-	echo "Ĉiuj testoj sukcesis."
+	printf '%s🎉 Ĉiuj testoj sukcesis.%s\n' "$$kolorbone" "$$kolornulo"
 
 instali: vaki
 	cd fontaro && $(DOSIERKREU) $(INSTALODUUMDOSIERUJO) $(INSTALOINKLUZIVARO) $(INSTALOTEKARO) $(INSTALOMANLIBRARO) $(INSTALOLMOD) $(INSTALOCMOD)

--- a/fontaro/Makefile
+++ b/fontaro/Makefile
@@ -29,9 +29,10 @@ MYOBJS=
 PLATS= aix bsd c89 freebsd generic linux macosx mingw posix solaris
 
 LUA_A=	liblua.a
+UTF8PROC_O= utf8proc/utf8proc.o
 CORE_O=	lapi.o lcode.o lctype.o ldebug.o ldo.o ldump.o lfunc.o lgc.o llex.o \
 	lmem.o lobject.o lopcodes.o lparser.o lstate.o lstring.o ltable.o \
-	ltm.o lundump.o lvm.o lzio.o
+	ltm.o lundump.o lvm.o lzio.o $(UTF8PROC_O)
 LIB_O=	lauxlib.o lbaselib.o lbitlib.o lcorolib.o ldblib.o liolib.o \
 	lmathlib.o loslib.o lstrlib.o ltablib.o lutf8lib.o loadlib.o linit.o
 BASE_O= $(CORE_O) $(LIB_O) $(MYOBJS)
@@ -193,5 +194,8 @@ lvm.o: lvm.c lprefix.h lua.h luaconf.h ldebug.h lstate.h lobject.h \
  ltable.h lvm.h
 lzio.o: lzio.c lprefix.h lua.h luaconf.h llimits.h lmem.h lstate.h \
  lobject.h ltm.h lzio.h
+
+utf8proc/utf8proc.o: utf8proc/utf8proc.c utf8proc/utf8proc.h
+	$(CC) $(CFLAGS) -c -o $@ utf8proc/utf8proc.c
 
 # (end of Makefile)

--- a/fontaro/llex.c
+++ b/fontaro/llex.c
@@ -623,15 +623,190 @@ static size_t updatematch (size_t current, int c, const unsigned char *word) {
   return 0;
 }
 
+static void citescapeerror (LexState *ls) {
+  const char *msg = luaO_pushfstring(ls->L,
+                   "invalid escape sequence near 'ĥaĵ'");
+  lexerror(ls, msg, TK_STRING);
+}
+
+static void citskipspaces (LexState *ls) {
+  while (lisspace(ls->current)) {
+    if (currIsNewline(ls))
+      inclinenumber(ls);
+    else
+      next(ls);
+  }
+}
+
+static void saveutf8codepoint (LexState *ls, unsigned long cp) {
+  char buff[UTF8BUFFSZ];
+  int n = luaO_utf8esc(buff, cp);
+  for (; n > 0; n--)
+    save(ls, buff[UTF8BUFFSZ - n]);
+}
+
+static int parsehexvalue (const char *s, size_t len, unsigned long *out) {
+  size_t i;
+  unsigned long v = 0;
+  if (len == 0)
+    return 0;
+  for (i = 0; i < len; i++) {
+    int c = cast_uchar(s[i]);
+    if (!lisxdigit(c))
+      return 0;
+    v = (v << 4) + luaO_hexavalue(c);
+  }
+  *out = v;
+  return 1;
+}
+
+static int parsedecvalue (const char *s, size_t len, unsigned long *out) {
+  size_t i;
+  unsigned long v = 0;
+  if (len == 0 || len > 3)
+    return 0;
+  for (i = 0; i < len; i++) {
+    int c = cast_uchar(s[i]);
+    if (!lisdigit(c))
+      return 0;
+    v = v * 10 + (unsigned long)(c - '0');
+  }
+  if (v > UCHAR_MAX)
+    return 0;
+  *out = v;
+  return 1;
+}
+
+static void readcitescapefield (LexState *ls, char *out, size_t outsz) {
+  size_t i = 0;
+  while (ls->current != '-') {
+    if (ls->current == EOZ || currIsNewline(ls))
+      citescapeerror(ls);
+    if (i + 1 >= outsz)
+      citescapeerror(ls);
+    out[i++] = cast(char, ls->current);
+    next(ls);
+  }
+  out[i] = '\0';
+  next(ls);  /* swallow '-' */
+}
+
+static void applycitescape (LexState *ls, const char *cmd, const char *p1) {
+  unsigned long val = 0;
+  size_t p1len = (p1 != NULL) ? strlen(p1) : 0;
+  if (strcmp(cmd, "a") == 0) { save(ls, '\a'); return; }
+  if (strcmp(cmd, "b") == 0) { save(ls, '\b'); return; }
+  if (strcmp(cmd, "f") == 0) { save(ls, '\f'); return; }
+  if (strcmp(cmd, "n") == 0 || strcmp(cmd, "novlinie") == 0) { save(ls, '\n'); return; }
+  if (strcmp(cmd, "r") == 0) { save(ls, '\r'); return; }
+  if (strcmp(cmd, "t") == 0) { save(ls, '\t'); return; }
+  if (strcmp(cmd, "v") == 0) { save(ls, '\v'); return; }
+  if (strcmp(cmd, "\\") == 0 || strcmp(cmd, "retrostreko") == 0) { save(ls, '\\'); return; }
+  if (strcmp(cmd, "\"") == 0 || strcmp(cmd, "citilo") == 0) { save(ls, '"'); return; }
+  if (strcmp(cmd, "'") == 0 || strcmp(cmd, "apostrofo") == 0) { save(ls, '\''); return; }
+  if (strcmp(cmd, "z") == 0 || strcmp(cmd, "spacglute") == 0) { citskipspaces(ls); return; }
+  if (strcmp(cmd, "x") == 0 || strcmp(cmd, "deksesume") == 0) {
+    if (p1 == NULL || p1len != 2 || !parsehexvalue(p1, p1len, &val))
+      citescapeerror(ls);
+    save(ls, cast(char, val));
+    return;
+  }
+  if (strcmp(cmd, "u") == 0 || strcmp(cmd, "unikodpunkte") == 0) {
+    if (p1 == NULL || !parsehexvalue(p1, p1len, &val))
+      citescapeerror(ls);
+    if (val > 0x10FFFF)
+      citescapeerror(ls);
+    saveutf8codepoint(ls, val);
+    return;
+  }
+  if (strcmp(cmd, "dekume") == 0) {
+    if (p1 == NULL || !parsedecvalue(p1, p1len, &val))
+      citescapeerror(ls);
+    save(ls, cast(char, val));
+    return;
+  }
+  citescapeerror(ls);
+}
+
+static void readcitescape_direct (LexState *ls) {
+  int c = ls->current;
+  unsigned long val;
+  char tmp[3];
+  if (c == EOZ)
+    citescapeerror(ls);
+  if (c == 'x') {
+    next(ls);  /* skip x */
+    if (!lisxdigit(ls->current))
+      citescapeerror(ls);
+    tmp[0] = cast(char, ls->current);
+    next(ls);
+    if (!lisxdigit(ls->current))
+      citescapeerror(ls);
+    tmp[1] = cast(char, ls->current);
+    tmp[2] = '\0';
+    next(ls);
+    if (!parsehexvalue(tmp, 2, &val))
+      citescapeerror(ls);
+    save(ls, cast(char, val));
+    return;
+  }
+  switch (c) {
+    case 'a': save(ls, '\a'); next(ls); return;
+    case 'b': save(ls, '\b'); next(ls); return;
+    case 'f': save(ls, '\f'); next(ls); return;
+    case 'n': save(ls, '\n'); next(ls); return;
+    case 'r': save(ls, '\r'); next(ls); return;
+    case 't': save(ls, '\t'); next(ls); return;
+    case 'v': save(ls, '\v'); next(ls); return;
+    case '\\': save(ls, '\\'); next(ls); return;
+    case '"': save(ls, '"'); next(ls); return;
+    case '\'': save(ls, '\''); next(ls); return;
+    case 'z':
+      next(ls);
+      citskipspaces(ls);
+      return;
+    default:
+      citescapeerror(ls);
+  }
+}
+
+static void readcitescape_extended (LexState *ls) {
+  char cmd[64];
+  char p1[64];
+  next(ls);  /* skip 'e' */
+  if (ls->current != '-')
+    citescapeerror(ls);
+  next(ls);  /* skip '-' */
+  readcitescapefield(ls, cmd, sizeof(cmd));  /* includes trailing '-' swallow */
+  if (strcmp(cmd, "x") == 0 || strcmp(cmd, "deksesume") == 0 ||
+      strcmp(cmd, "u") == 0 || strcmp(cmd, "unikodpunkte") == 0 ||
+      strcmp(cmd, "dekume") == 0) {
+    readcitescapefield(ls, p1, sizeof(p1));
+    applycitescape(ls, cmd, p1);
+    return;
+  }
+  applycitescape(ls, cmd, NULL);
+}
+
+static void readcitescape (LexState *ls) {
+  if (ls->current == 'e')
+    readcitescape_extended(ls);
+  else
+    readcitescape_direct(ls);
+}
+
 static void read_cit_string (LexState *ls, SemInfo *seminfo) {
   int line = ls->linenumber;  /* initial line (for error message) */
   static const unsigned char close_malcit[] = "malcit";
   static const unsigned char close_cxit[] = {0xC4, 0x89, 'i', 't'};
   static const unsigned char esc_hxaux[] = {0xC4, 0xA5, 'a', 0xC5, 0xAD};  /* ĥaŭ */
+  static const unsigned char esc_hxaj[] = {0xC4, 0xA5, 'a', 0xC4, 0xB5};   /* ĥaĵ */
   size_t m_malcit = 0;
   size_t m_cxit = 0;
-  size_t m_esc = 0;
+  size_t m_esc_literal = 0;
+  size_t m_esc_special = 0;
   int escaped_next = 0;
+  int protect_trailing_sep = 0;
 
   /* Post 'cit', ignore one initial separator character if present. */
   if (currentisseparator(ls)) {
@@ -657,22 +832,38 @@ static void read_cit_string (LexState *ls, SemInfo *seminfo) {
     }
     else
       save_and_next(ls);
+    protect_trailing_sep = 0;
 
     {
       int c = (unsigned char)luaZ_buffer(ls->buff)[luaZ_bufflen(ls->buff) - 1];
       if (escaped_next) {
         escaped_next = 0;
-        m_esc = 0;
+        protect_trailing_sep = 1;
+        m_esc_literal = 0;
+        m_esc_special = 0;
         m_malcit = 0;
         m_cxit = 0;
         continue;
       }
 
-      m_esc = updatematch(m_esc, c, esc_hxaux);
-      if (m_esc == sizeof(esc_hxaux)) {
+      m_esc_literal = updatematch(m_esc_literal, c, esc_hxaux);
+      if (m_esc_literal == sizeof(esc_hxaux)) {
         luaZ_buffremove(ls->buff, sizeof(esc_hxaux));
         escaped_next = 1;
-        m_esc = 0;
+        m_esc_literal = 0;
+        m_esc_special = 0;
+        m_malcit = 0;
+        m_cxit = 0;
+        continue;
+      }
+
+      m_esc_special = updatematch(m_esc_special, c, esc_hxaj);
+      if (m_esc_special == sizeof(esc_hxaj)) {
+        luaZ_buffremove(ls->buff, sizeof(esc_hxaj));
+        readcitescape(ls);
+        protect_trailing_sep = 1;
+        m_esc_literal = 0;
+        m_esc_special = 0;
         m_malcit = 0;
         m_cxit = 0;
         continue;
@@ -693,9 +884,11 @@ static void read_cit_string (LexState *ls, SemInfo *seminfo) {
       if (isworddelimiter(before) && isworddelimiter(ls->current)) {
         size_t sepbytes;
         luaZ_buffremove(ls->buff, close_len);
-        sepbytes = trailingseparatorsize(ls->buff);
-        if (sepbytes > 0)
-          luaZ_buffremove(ls->buff, sepbytes);
+        if (!protect_trailing_sep) {
+          sepbytes = trailingseparatorsize(ls->buff);
+          if (sepbytes > 0)
+            luaZ_buffremove(ls->buff, sepbytes);
+        }
         seminfo->ts = luaX_newstring(ls, luaZ_buffer(ls->buff), luaZ_bufflen(ls->buff));
         return;
       }

--- a/fontaro/llex.c
+++ b/fontaro/llex.c
@@ -694,13 +694,13 @@ static void readcitescapefield (LexState *ls, char *out, size_t outsz) {
 static void applycitescape (LexState *ls, const char *cmd, const char *p1) {
   unsigned long val = 0;
   size_t p1len = (p1 != NULL) ? strlen(p1) : 0;
-  if (strcmp(cmd, "a") == 0) { save(ls, '\a'); return; }
-  if (strcmp(cmd, "b") == 0) { save(ls, '\b'); return; }
-  if (strcmp(cmd, "f") == 0) { save(ls, '\f'); return; }
+  if (strcmp(cmd, "a") == 0 || strcmp(cmd, "alarme") == 0) { save(ls, '\a'); return; }
+  if (strcmp(cmd, "b") == 0 || strcmp(cmd, "retropaŝe") == 0) { save(ls, '\b'); return; }
+  if (strcmp(cmd, "f") == 0 || strcmp(cmd, "paĝosalte") == 0) { save(ls, '\f'); return; }
   if (strcmp(cmd, "n") == 0 || strcmp(cmd, "novlinie") == 0) { save(ls, '\n'); return; }
-  if (strcmp(cmd, "r") == 0) { save(ls, '\r'); return; }
-  if (strcmp(cmd, "t") == 0) { save(ls, '\t'); return; }
-  if (strcmp(cmd, "v") == 0) { save(ls, '\v'); return; }
+  if (strcmp(cmd, "r") == 0 || strcmp(cmd, "ĉaretrevene") == 0) { save(ls, '\r'); return; }
+  if (strcmp(cmd, "t") == 0 || strcmp(cmd, "tabe") == 0) { save(ls, '\t'); return; }
+  if (strcmp(cmd, "v") == 0 || strcmp(cmd, "vertikalatabe") == 0) { save(ls, '\v'); return; }
   if (strcmp(cmd, "\\") == 0 || strcmp(cmd, "retrostreko") == 0) { save(ls, '\\'); return; }
   if (strcmp(cmd, "\"") == 0 || strcmp(cmd, "citilo") == 0) { save(ls, '"'); return; }
   if (strcmp(cmd, "'") == 0 || strcmp(cmd, "apostrofo") == 0) { save(ls, '\''); return; }
@@ -728,46 +728,68 @@ static void applycitescape (LexState *ls, const char *cmd, const char *p1) {
   citescapeerror(ls);
 }
 
-static void readcitescape_direct (LexState *ls) {
-  int c = ls->current;
-  unsigned long val;
-  char tmp[3];
-  if (c == EOZ)
+static int citescapehasparam (const char *cmd) {
+  return (strcmp(cmd, "x") == 0 || strcmp(cmd, "deksesume") == 0 ||
+          strcmp(cmd, "u") == 0 || strcmp(cmd, "unikodpunkte") == 0 ||
+          strcmp(cmd, "dekume") == 0);
+}
+
+static void readcitescapedirectparam (LexState *ls, const char *cmd, char *out, size_t outsz) {
+  size_t i = 0;
+  if (strcmp(cmd, "x") == 0 || strcmp(cmd, "deksesume") == 0) {
+    while (lisxdigit(ls->current) && i < 2) {
+      out[i++] = cast(char, ls->current);
+      next(ls);
+    }
+    if (i != 2)
+      citescapeerror(ls);
+  }
+  else if (strcmp(cmd, "u") == 0 || strcmp(cmd, "unikodpunkte") == 0) {
+    while (lisxdigit(ls->current)) {
+      if (i + 1 >= outsz)
+        citescapeerror(ls);
+      out[i++] = cast(char, ls->current);
+      next(ls);
+    }
+    if (i == 0)
+      citescapeerror(ls);
+  }
+  else if (strcmp(cmd, "dekume") == 0) {
+    while (lisdigit(ls->current) && i < 3) {
+      out[i++] = cast(char, ls->current);
+      next(ls);
+    }
+    if (i == 0)
+      citescapeerror(ls);
+  }
+  else
     citescapeerror(ls);
-  if (c == 'x') {
-    next(ls);  /* skip x */
-    if (!lisxdigit(ls->current))
+  out[i] = '\0';
+}
+
+static void readcitescape_directlong (LexState *ls) {
+  char cmd[64];
+  char p1[64];
+  size_t i = 0;
+  while (lislalpha(ls->current)) {
+    if (i + 1 >= sizeof(cmd))
       citescapeerror(ls);
-    tmp[0] = cast(char, ls->current);
+    cmd[i++] = cast(char, ls->current);
     next(ls);
-    if (!lisxdigit(ls->current))
+  }
+  cmd[i] = '\0';
+  if (i <= 1)  /* monoletter direct commands are intentionally invalid */
+    citescapeerror(ls);
+
+  if (citescapehasparam(cmd)) {
+    if (ls->current != '-')
       citescapeerror(ls);
-    tmp[1] = cast(char, ls->current);
-    tmp[2] = '\0';
-    next(ls);
-    if (!parsehexvalue(tmp, 2, &val))
-      citescapeerror(ls);
-    save(ls, cast(char, val));
+    next(ls);  /* skip '-' */
+    readcitescapedirectparam(ls, cmd, p1, sizeof(p1));
+    applycitescape(ls, cmd, p1);
     return;
   }
-  switch (c) {
-    case 'a': save(ls, '\a'); next(ls); return;
-    case 'b': save(ls, '\b'); next(ls); return;
-    case 'f': save(ls, '\f'); next(ls); return;
-    case 'n': save(ls, '\n'); next(ls); return;
-    case 'r': save(ls, '\r'); next(ls); return;
-    case 't': save(ls, '\t'); next(ls); return;
-    case 'v': save(ls, '\v'); next(ls); return;
-    case '\\': save(ls, '\\'); next(ls); return;
-    case '"': save(ls, '"'); next(ls); return;
-    case '\'': save(ls, '\''); next(ls); return;
-    case 'z':
-      next(ls);
-      citskipspaces(ls);
-      return;
-    default:
-      citescapeerror(ls);
-  }
+  applycitescape(ls, cmd, NULL);
 }
 
 static void readcitescape_extended (LexState *ls) {
@@ -778,9 +800,7 @@ static void readcitescape_extended (LexState *ls) {
     citescapeerror(ls);
   next(ls);  /* skip '-' */
   readcitescapefield(ls, cmd, sizeof(cmd));  /* includes trailing '-' swallow */
-  if (strcmp(cmd, "x") == 0 || strcmp(cmd, "deksesume") == 0 ||
-      strcmp(cmd, "u") == 0 || strcmp(cmd, "unikodpunkte") == 0 ||
-      strcmp(cmd, "dekume") == 0) {
+  if (citescapehasparam(cmd)) {
     readcitescapefield(ls, p1, sizeof(p1));
     applycitescape(ls, cmd, p1);
     return;
@@ -789,10 +809,10 @@ static void readcitescape_extended (LexState *ls) {
 }
 
 static void readcitescape (LexState *ls) {
-  if (ls->current == 'e')
+  if (ls->current == 'e' && ls->z->n > 0 && ls->z->p[0] == '-')
     readcitescape_extended(ls);
   else
-    readcitescape_direct(ls);
+    readcitescape_directlong(ls);
 }
 
 static void read_cit_string (LexState *ls, SemInfo *seminfo) {

--- a/fontaro/llex.c
+++ b/fontaro/llex.c
@@ -556,8 +556,11 @@ static void read_string (LexState *ls, int del, SemInfo *seminfo) {
 /* Helper to decode UTF-8 sequence to codepoint */
 static utf8proc_int32_t utf8_to_codepoint(const unsigned char *str, size_t len) {
   utf8proc_int32_t codepoint;
+  utf8proc_ssize_t nread;
   if (len == 0) return -1;
-  utf8proc_iterate(str, len, &codepoint);
+  nread = utf8proc_iterate(str, len, &codepoint);
+  if (nread < 0)
+    return -1;
   return codepoint;
 }
 
@@ -581,29 +584,34 @@ static int isworddelimiter_utf8 (unsigned char c1, unsigned char c2, unsigned ch
     /* ASCII case */
     return (lisspace(c1) || (!lislalnum(c1) && c1 != '_'));
   }
-  
+
+  if (c1 == 0xC2 && c2 == 0xB7)  /* U+00B7 middle dot, kept for identifiers */
+    return 0;
+
   /* Multi-byte UTF-8 sequence */
   unsigned char bytes[4] = {c1, c2, c3, 0};
   utf8proc_int32_t codepoint = utf8_to_codepoint(bytes, 3);
-  
+
   if (codepoint < 0)
     return 1;  /* Invalid UTF-8 treated as separator */
-  
+  if (codepoint == 0x02C7)  /* U+02C7 CARON: spacing accent, separator in cit framing */
+    return 1;
+
   /* Check Unicode category: separators (Zs, Zl, Zp) or non-word chars */
   utf8proc_category_t cat = utf8proc_category(codepoint);
-  
+
   /* Separators: Zs (23), Zl (24), Zp (25) */
   if (cat == 23 || cat == 24 || cat == 25)
     return 1;
-  
+
   /* Punctuation and symbols: Pd (13), Ps (14), Pe (15), Pi (16), Pf (17), Po (11), Sm (19), Sc (20), Sk (21), So (22) */
   if ((cat >= 13 && cat <= 17) || cat == 11 || (cat >= 19 && cat <= 22))
     return 1;
-  
+
   /* Word characters: letters, digits, marks, Pc */
   if (utf8_is_word_char(codepoint))
     return 0;
-  
+
   return 1;  /* Everything else is a separator */
 }
 
@@ -623,11 +631,7 @@ static void skiponeutf8char (LexState *ls) {
 }
 
 static int isutf8separator (unsigned char c1, unsigned char c2, unsigned char c3) {
-  if (c1 < 0x80)
-    return (lisspace(c1) || (!lislalnum(c1) && c1 != '_'));
-  if (c1 == 0xC2 && c2 == 0xB7)  /* U+00B7 middle dot, kept for identifiers */
-    return 0;
-  return !luai_isutf8alpha(c1, c2, c3);
+  return isworddelimiter_utf8(c1, c2, c3);
 }
 
 static int currentisseparator (LexState *ls) {
@@ -1003,6 +1007,8 @@ static void read_cit_string (LexState *ls, SemInfo *seminfo) {
 static int isidentifiercont(LexState *ls) {
   unsigned char c1;
   unsigned char c2 = 0, c3 = 0;
+  utf8proc_int32_t codepoint;
+  unsigned char bytes[4];
   /* ponytail: EOZ is -1; casting to unsigned makes it 255 and would
      incorrectly look like UTF-8 data at end-of-file. */
   if (ls->current == EOZ)
@@ -1021,7 +1027,16 @@ static int isidentifiercont(LexState *ls) {
     c3 = (unsigned char)ls->z->p[1];
   if (c1 == 0xC2 && c2 == 0xB7)  /* U+00B7 */
     return 1;
-  return luai_isutf8alpha(c1, c2, c3);
+  bytes[0] = c1;
+  bytes[1] = c2;
+  bytes[2] = c3;
+  bytes[3] = 0;
+  codepoint = utf8_to_codepoint(bytes, 3);
+  if (codepoint < 0)
+    return 0;
+  if (codepoint == 0x02C7)  /* U+02C7 CARON is not an identifier continuation */
+    return 0;
+  return utf8_is_word_char(codepoint);
 }
 
 static void saveutf8seq(LexState *ls) {

--- a/fontaro/llex.c
+++ b/fontaro/llex.c
@@ -552,18 +552,183 @@ static void read_string (LexState *ls, int del, SemInfo *seminfo) {
                                    luaZ_bufflen(ls->buff) - 2);
 }
 
+static int isworddelimiter (int c) {
+  if (c == EOZ) return 1;
+  if (lisspace(c)) return 1;
+  if ((unsigned char)c >= 0x80) return 0;
+  return !lislalnum(c) && c != '_';
+}
+
+static int isutf8separator (unsigned char c1, unsigned char c2, unsigned char c3) {
+  if (c1 < 0x80)
+    return (lisspace(c1) || (!lislalnum(c1) && c1 != '_'));
+  if (c1 == 0xC2 && c2 == 0xB7)  /* U+00B7 middle dot, kept for identifiers */
+    return 0;
+  return !luai_isutf8alpha(c1, c2, c3);
+}
+
+static void skiponeutf8char (LexState *ls) {
+  unsigned char c1 = cast_uchar(ls->current);
+  next(ls);
+  if (c1 >= 0xE0) {
+    if (luai_isutf8cont(cast_uchar(ls->current)))
+      next(ls);
+    if (luai_isutf8cont(cast_uchar(ls->current)))
+      next(ls);
+  }
+  else if (c1 >= 0xC0) {
+    if (luai_isutf8cont(cast_uchar(ls->current)))
+      next(ls);
+  }
+}
+
+static int currentisseparator (LexState *ls) {
+  unsigned char c1, c2 = 0, c3 = 0;
+  if (ls->current == EOZ)
+    return 0;
+  c1 = cast_uchar(ls->current);
+  if (c1 < 0x80)
+    return isutf8separator(c1, 0, 0);
+  if (ls->z->n > 0)
+    c2 = cast_uchar(ls->z->p[0]);
+  if (ls->z->n > 1)
+    c3 = cast_uchar(ls->z->p[1]);
+  return isutf8separator(c1, c2, c3);
+}
+
+static size_t trailingseparatorsize (Mbuffer *b) {
+  size_t n = luaZ_bufflen(b);
+  size_t start;
+  unsigned char c1, c2 = 0, c3 = 0;
+  if (n == 0)
+    return 0;
+  start = n - 1;
+  while (start > 0 && luai_isutf8cont(cast_uchar(luaZ_buffer(b)[start])))
+    start--;
+  c1 = cast_uchar(luaZ_buffer(b)[start]);
+  if (start + 1 < n)
+    c2 = cast_uchar(luaZ_buffer(b)[start + 1]);
+  if (start + 2 < n)
+    c3 = cast_uchar(luaZ_buffer(b)[start + 2]);
+  if (c1 == '\n' || c1 == '\r')
+    return 0;
+  if (isutf8separator(c1, c2, c3))
+    return n - start;
+  return 0;
+}
+
+static size_t updatematch (size_t current, int c, const unsigned char *word) {
+  if ((unsigned char)c == word[current]) return current + 1;
+  if ((unsigned char)c == word[0]) return 1;
+  return 0;
+}
+
+static void read_cit_string (LexState *ls, SemInfo *seminfo) {
+  int line = ls->linenumber;  /* initial line (for error message) */
+  static const unsigned char close_malcit[] = "malcit";
+  static const unsigned char close_cxit[] = {0xC4, 0x89, 'i', 't'};
+  static const unsigned char esc_hxaux[] = {0xC4, 0xA5, 'a', 0xC5, 0xAD};  /* ĥaŭ */
+  size_t m_malcit = 0;
+  size_t m_cxit = 0;
+  size_t m_esc = 0;
+  int escaped_next = 0;
+
+  /* Post 'cit', ignore one initial separator character if present. */
+  if (currentisseparator(ls)) {
+    if (currIsNewline(ls))
+      inclinenumber(ls);
+    else if (cast_uchar(ls->current) >= 0x80)
+      skiponeutf8char(ls);
+    else
+      next(ls);
+  }
+
+  luaZ_resetbuffer(ls->buff);
+  for (;;) {
+    if (ls->current == EOZ) {
+      const char *msg = luaO_pushfstring(ls->L,
+                   "unfinished cit string (starting at line %d) near <eof>", line);
+      lexerror(ls, msg, 0);
+    }
+
+    if (currIsNewline(ls)) {
+      save(ls, '\n');
+      inclinenumber(ls);
+    }
+    else
+      save_and_next(ls);
+
+    {
+      int c = (unsigned char)luaZ_buffer(ls->buff)[luaZ_bufflen(ls->buff) - 1];
+      if (escaped_next) {
+        escaped_next = 0;
+        m_esc = 0;
+        m_malcit = 0;
+        m_cxit = 0;
+        continue;
+      }
+
+      m_esc = updatematch(m_esc, c, esc_hxaux);
+      if (m_esc == sizeof(esc_hxaux)) {
+        luaZ_buffremove(ls->buff, sizeof(esc_hxaux));
+        escaped_next = 1;
+        m_esc = 0;
+        m_malcit = 0;
+        m_cxit = 0;
+        continue;
+      }
+
+      m_malcit = updatematch(m_malcit, c, close_malcit);
+      m_cxit = updatematch(m_cxit, c, close_cxit);
+    }
+
+    if (m_malcit == sizeof(close_malcit) - 1 || m_cxit == sizeof(close_cxit)) {
+      size_t close_len = (m_malcit == sizeof(close_malcit) - 1)
+                       ? (sizeof(close_malcit) - 1)
+                       : sizeof(close_cxit);
+      size_t start = luaZ_bufflen(ls->buff) - close_len;
+      int has_before = (start > 0);
+      int before = has_before ? (unsigned char)luaZ_buffer(ls->buff)[start - 1] : ' ';
+
+      if (isworddelimiter(before) && isworddelimiter(ls->current)) {
+        size_t sepbytes;
+        luaZ_buffremove(ls->buff, close_len);
+        sepbytes = trailingseparatorsize(ls->buff);
+        if (sepbytes > 0)
+          luaZ_buffremove(ls->buff, sepbytes);
+        seminfo->ts = luaX_newstring(ls, luaZ_buffer(ls->buff), luaZ_bufflen(ls->buff));
+        return;
+      }
+    }
+  }
+}
+
 /*
 ** Check if current position starts a valid identifier continuation in UTF-8
 ** Handles multi-byte sequences transparently
 */
 static int isidentifiercont(LexState *ls) {
+  unsigned char c1;
+  unsigned char c2 = 0, c3 = 0;
   /* ponytail: EOZ is -1; casting to unsigned makes it 255 and would
-     incorrectly look like a UTF-8 continuation byte at end-of-file. */
+     incorrectly look like UTF-8 data at end-of-file. */
   if (ls->current == EOZ)
     return 0;
-  unsigned char c1 = (unsigned char)ls->current;
-  /* ASCII identifier continuation or any non-ASCII UTF-8 byte. */
-  return lislalnum(c1) || c1 >= 0x80;
+  c1 = (unsigned char)ls->current;
+  /* ASCII identifier continuation. */
+  if (lislalnum(c1))
+    return 1;
+  /* Non-ASCII: accept UTF-8 letters and U+00B7 (middle dot), used in
+     existing test names. This lets punctuation like '¡' be separators. */
+  if (c1 < 0xC0)
+    return 0;
+  if (ls->z->n > 0)
+    c2 = (unsigned char)ls->z->p[0];
+  if (ls->z->n > 1)
+    c3 = (unsigned char)ls->z->p[1];
+  if (c1 == 0xC2 && c2 == 0xB7)  /* U+00B7 */
+    return 1;
+  return luai_isutf8alpha(c1, c2, c3);
 }
 
 static void saveutf8seq(LexState *ls) {
@@ -626,6 +791,12 @@ static int isselfalias (TString *ts) {
   size_t longo = tsslen(ts);
   const char *nomo = getstr(ts);
   return (longo == 3 && memcmp(nomo, "sia", 3) == 0);
+}
+
+static int iscitopenalias (TString *ts) {
+  size_t longo = tsslen(ts);
+  const char *nomo = getstr(ts);
+  return (longo == 3 && memcmp(nomo, "cit", 3) == 0);
 }
 
 static int nametotoken (TString *ts) {
@@ -755,6 +926,10 @@ static int llex (LexState *ls, SemInfo *seminfo) {
           }
           ts = luaX_newstring(ls, luaZ_buffer(ls->buff),
                                   luaZ_bufflen(ls->buff));
+          if (iscitopenalias(ts)) {
+            read_cit_string(ls, seminfo);
+            return TK_STRING;
+          }
           if (isselfalias(ts))
             ts = luaS_newliteral(ls->L, "self");
           seminfo->ts = ts;
@@ -809,6 +984,10 @@ static int llex (LexState *ls, SemInfo *seminfo) {
           
           ts = luaX_newstring(ls, luaZ_buffer(ls->buff),
                                   luaZ_bufflen(ls->buff));
+          if (iscitopenalias(ts)) {
+            read_cit_string(ls, seminfo);
+            return TK_STRING;
+          }
           if (isselfalias(ts))
             ts = luaS_newliteral(ls->L, "self");
           seminfo->ts = ts;

--- a/fontaro/llex.c
+++ b/fontaro/llex.c
@@ -553,66 +553,56 @@ static void read_string (LexState *ls, int del, SemInfo *seminfo) {
                                    luaZ_bufflen(ls->buff) - 2);
 }
 
-/* Helper to decode UTF-8 sequence to codepoint */
-static utf8proc_int32_t utf8tocodepoint(const unsigned char *str, size_t len) {
+static size_t utf8seqlen (unsigned char c1) {
+  if (c1 < 0x80) return 1;
+  if ((c1 & 0xE0) == 0xC0) return 2;
+  if ((c1 & 0xF0) == 0xE0) return 3;
+  if ((c1 & 0xF8) == 0xF0) return 4;
+  return 1;  /* invalid lead byte; handled by decoder */
+}
+
+/* Decode one UTF-8 codepoint from up to 4 already-peeked bytes. */
+static utf8proc_int32_t utf8tocodepoint (unsigned char c1, unsigned char c2,
+                                         unsigned char c3, unsigned char c4) {
+  unsigned char bytes[4];
   utf8proc_int32_t codepoint;
   utf8proc_ssize_t nread;
-  if (len == 0) return -1;
-  nread = utf8proc_iterate(str, len, &codepoint);
+  size_t len = utf8seqlen(c1);
+  bytes[0] = c1;
+  bytes[1] = c2;
+  bytes[2] = c3;
+  bytes[3] = c4;
+  nread = utf8proc_iterate(bytes, (utf8proc_ssize_t)len, &codepoint);
   if (nread < 0)
     return -1;
   return codepoint;
 }
 
-/* Check if a Unicode codepoint is a word character (letter, digit, connector) */
-static int utf8iswordchar(utf8proc_int32_t codepoint) {
-  utf8proc_category_t cat = utf8proc_category(codepoint);
-  /* Letters (L*): LU, LL, LT, LM, LO */
-  if (cat >= 1 && cat <= 5) return 1;
-  /* Digits (ND) */
-  if (cat == 9) return 1;
-  /* Connector punctuation (Pc, which includes underscore-like chars) */
-  if (cat == 12) return 1;
-  /* Mark characters (combining marks are part of base character) */
-  if (cat >= 6 && cat <= 8) return 1;
+/* Single source of truth for Unicode identifier continuation policy. */
+static int iswordcodepoint (utf8proc_int32_t codepoint) {
+  utf8proc_category_t cat;
+  if (codepoint == 0x00B7)  /* U+00B7 MIDDLE DOT kept for existing identifiers */
+    return 1;
+  if (codepoint == 0x02C7)  /* U+02C7 CARON used as separator in cit framing */
+    return 0;
+  cat = utf8proc_category(codepoint);
+  if (cat >= UTF8PROC_CATEGORY_LU && cat <= UTF8PROC_CATEGORY_LO) return 1;  /* letters */
+  if (cat >= UTF8PROC_CATEGORY_MN && cat <= UTF8PROC_CATEGORY_ME) return 1;  /* combining marks */
+  if (cat == UTF8PROC_CATEGORY_ND) return 1;                                  /* decimal digits */
+  if (cat == UTF8PROC_CATEGORY_PC) return 1;                                  /* connector punct */
   return 0;
 }
 
-/* Enhanced word delimiter check using utf8proc for Unicode support */
-static int isworddelimiterutf8 (unsigned char c1, unsigned char c2, unsigned char c3) {
-  if (c1 < 0x80) {
-    /* ASCII case */
+/* Unicode word delimiter = not an identifier continuation char. */
+static int isworddelimiterutf8 (unsigned char c1, unsigned char c2,
+                                unsigned char c3, unsigned char c4) {
+  utf8proc_int32_t codepoint;
+  if (c1 < 0x80)
     return (lisspace(c1) || (!lislalnum(c1) && c1 != '_'));
-  }
-
-  if (c1 == 0xC2 && c2 == 0xB7)  /* U+00B7 middle dot, kept for identifiers */
-    return 0;
-
-  /* Multi-byte UTF-8 sequence */
-  unsigned char bytes[4] = {c1, c2, c3, 0};
-  utf8proc_int32_t codepoint = utf8tocodepoint(bytes, 3);
-
+  codepoint = utf8tocodepoint(c1, c2, c3, c4);
   if (codepoint < 0)
-    return 1;  /* Invalid UTF-8 treated as separator */
-  if (codepoint == 0x02C7)  /* U+02C7 CARON: spacing accent, separator in cit framing */
-    return 1;
-
-  /* Check Unicode category: separators (Zs, Zl, Zp) or non-word chars */
-  utf8proc_category_t cat = utf8proc_category(codepoint);
-
-  /* Separators: Zs (23), Zl (24), Zp (25) */
-  if (cat == 23 || cat == 24 || cat == 25)
-    return 1;
-
-  /* Punctuation and symbols: Pd (13), Ps (14), Pe (15), Pi (16), Pf (17), Po (11), Sm (19), Sc (20), Sk (21), So (22) */
-  if ((cat >= 13 && cat <= 17) || cat == 11 || (cat >= 19 && cat <= 22))
-    return 1;
-
-  /* Word characters: letters, digits, marks, Pc */
-  if (utf8iswordchar(codepoint))
-    return 0;
-
-  return 1;  /* Everything else is a separator */
+    return 1;  /* invalid UTF-8 treated as separator */
+  return !iswordcodepoint(codepoint);
 }
 
 static void skiponeutf8char (LexState *ls) {
@@ -630,22 +620,18 @@ static void skiponeutf8char (LexState *ls) {
   }
 }
 
-static int isutf8separator (unsigned char c1, unsigned char c2, unsigned char c3) {
-  return isworddelimiterutf8(c1, c2, c3);
-}
-
 static int currentisseparator (LexState *ls) {
-  unsigned char c1, c2 = 0, c3 = 0;
+  unsigned char c1, c2 = 0, c3 = 0, c4 = 0;
   if (ls->current == EOZ)
     return 0;
   c1 = cast_uchar(ls->current);
-  if (c1 < 0x80)
-    return isutf8separator(c1, 0, 0);
   if (ls->z->n > 0)
     c2 = cast_uchar(ls->z->p[0]);
   if (ls->z->n > 1)
     c3 = cast_uchar(ls->z->p[1]);
-  return isutf8separator(c1, c2, c3);
+  if (ls->z->n > 2)
+    c4 = cast_uchar(ls->z->p[2]);
+  return isworddelimiterutf8(c1, c2, c3, c4);
 }
 
 /* Find the start of a UTF-8 character at or before a buffer position */
@@ -657,18 +643,21 @@ static size_t find_utf8_start(const unsigned char *buffer, size_t pos) {
 
 /* Check if byte at buffer position (possibly mid-UTF-8) is a word delimiter */
 static int bufferposisworddelim(const unsigned char *buffer, size_t buflen, size_t pos) {
+  unsigned char c4 = 0;
   if (pos >= buflen)
     return 1;
   size_t start = find_utf8_start(buffer, pos);
   unsigned char c1 = buffer[start];
   unsigned char c2 = (start + 1 < buflen) ? buffer[start + 1] : 0;
   unsigned char c3 = (start + 2 < buflen) ? buffer[start + 2] : 0;
-  return isworddelimiterutf8(c1, c2, c3);
+  if (start + 3 < buflen)
+    c4 = buffer[start + 3];
+  return isworddelimiterutf8(c1, c2, c3, c4);
 }
 
 /* Check if current input position is a word delimiter */
 static int currentposisworddelim(LexState *ls) {
-  unsigned char c1, c2 = 0, c3 = 0;
+  unsigned char c1, c2 = 0, c3 = 0, c4 = 0;
   if (ls->current == EOZ)
     return 1;
   c1 = (unsigned char)ls->current;
@@ -676,13 +665,15 @@ static int currentposisworddelim(LexState *ls) {
     c2 = (unsigned char)ls->z->p[0];
   if (ls->z->n > 1)
     c3 = (unsigned char)ls->z->p[1];
-  return isworddelimiterutf8(c1, c2, c3);
+  if (ls->z->n > 2)
+    c4 = (unsigned char)ls->z->p[2];
+  return isworddelimiterutf8(c1, c2, c3, c4);
 }
 
 static size_t trailingseparatorsize (Mbuffer *b) {
   size_t n = luaZ_bufflen(b);
   size_t start;
-  unsigned char c1, c2 = 0, c3 = 0;
+  unsigned char c1, c2 = 0, c3 = 0, c4 = 0;
   if (n == 0)
     return 0;
   start = n - 1;
@@ -693,9 +684,11 @@ static size_t trailingseparatorsize (Mbuffer *b) {
     c2 = cast_uchar(luaZ_buffer(b)[start + 1]);
   if (start + 2 < n)
     c3 = cast_uchar(luaZ_buffer(b)[start + 2]);
+  if (start + 3 < n)
+    c4 = cast_uchar(luaZ_buffer(b)[start + 3]);
   if (c1 == '\n' || c1 == '\r')
     return 0;
-  if (isutf8separator(c1, c2, c3))
+  if (isworddelimiterutf8(c1, c2, c3, c4))
     return n - start;
   return 0;
 }
@@ -1006,9 +999,8 @@ static void read_cit_string (LexState *ls, SemInfo *seminfo) {
 */
 static int isidentifiercont(LexState *ls) {
   unsigned char c1;
-  unsigned char c2 = 0, c3 = 0;
+  unsigned char c2 = 0, c3 = 0, c4 = 0;
   utf8proc_int32_t codepoint;
-  unsigned char bytes[4];
   /* ponytail: EOZ is -1; casting to unsigned makes it 255 and would
      incorrectly look like UTF-8 data at end-of-file. */
   if (ls->current == EOZ)
@@ -1025,18 +1017,12 @@ static int isidentifiercont(LexState *ls) {
     c2 = (unsigned char)ls->z->p[0];
   if (ls->z->n > 1)
     c3 = (unsigned char)ls->z->p[1];
-  if (c1 == 0xC2 && c2 == 0xB7)  /* U+00B7 */
-    return 1;
-  bytes[0] = c1;
-  bytes[1] = c2;
-  bytes[2] = c3;
-  bytes[3] = 0;
-  codepoint = utf8tocodepoint(bytes, 3);
+  if (ls->z->n > 2)
+    c4 = (unsigned char)ls->z->p[2];
+  codepoint = utf8tocodepoint(c1, c2, c3, c4);
   if (codepoint < 0)
     return 0;
-  if (codepoint == 0x02C7)  /* U+02C7 CARON is not an identifier continuation */
-    return 0;
-  return utf8iswordchar(codepoint);
+  return iswordcodepoint(codepoint);
 }
 
 static void saveutf8seq(LexState *ls) {

--- a/fontaro/llex.c
+++ b/fontaro/llex.c
@@ -625,7 +625,7 @@ static size_t updatematch (size_t current, int c, const unsigned char *word) {
 
 static void citescapeerror (LexState *ls) {
   const char *msg = luaO_pushfstring(ls->L,
-                   "invalid escape sequence near 'ĥaĵ'");
+                   "invalid escape sequence near 'ĥap'");
   lexerror(ls, msg, TK_STRING);
 }
 
@@ -820,7 +820,7 @@ static void read_cit_string (LexState *ls, SemInfo *seminfo) {
   static const unsigned char close_malcit[] = "malcit";
   static const unsigned char close_cxit[] = {0xC4, 0x89, 'i', 't'};
   static const unsigned char esc_hxaux[] = {0xC4, 0xA5, 'a', 0xC5, 0xAD};  /* ĥaŭ */
-  static const unsigned char esc_hxaj[] = {0xC4, 0xA5, 'a', 0xC4, 0xB5};   /* ĥaĵ */
+  static const unsigned char esc_hxap[] = {0xC4, 0xA5, 'a', 'p'};   /* ĥap */
   size_t m_malcit = 0;
   size_t m_cxit = 0;
   size_t m_esc_literal = 0;
@@ -877,9 +877,9 @@ static void read_cit_string (LexState *ls, SemInfo *seminfo) {
         continue;
       }
 
-      m_esc_special = updatematch(m_esc_special, c, esc_hxaj);
-      if (m_esc_special == sizeof(esc_hxaj)) {
-        luaZ_buffremove(ls->buff, sizeof(esc_hxaj));
+      m_esc_special = updatematch(m_esc_special, c, esc_hxap);
+      if (m_esc_special == sizeof(esc_hxap)) {
+        luaZ_buffremove(ls->buff, sizeof(esc_hxap));
         readcitescape(ls);
         protect_trailing_sep = 1;
         m_esc_literal = 0;

--- a/fontaro/llex.c
+++ b/fontaro/llex.c
@@ -15,6 +15,7 @@
 
 #include "lua.h"
 
+#include "utf8proc/utf8proc.h"
 #include "lctype.h"
 #include "ldebug.h"
 #include "ldo.h"
@@ -552,19 +553,65 @@ static void read_string (LexState *ls, int del, SemInfo *seminfo) {
                                    luaZ_bufflen(ls->buff) - 2);
 }
 
+/* Helper to decode UTF-8 sequence to codepoint */
+static utf8proc_int32_t utf8_to_codepoint(const unsigned char *str, size_t len) {
+  utf8proc_int32_t codepoint;
+  if (len == 0) return -1;
+  utf8proc_iterate(str, len, &codepoint);
+  return codepoint;
+}
+
+/* Check if a Unicode codepoint is a word character (letter, digit, connector) */
+static int utf8_is_word_char(utf8proc_int32_t codepoint) {
+  utf8proc_category_t cat = utf8proc_category(codepoint);
+  /* Letters (L*): LU, LL, LT, LM, LO */
+  if (cat >= 1 && cat <= 5) return 1;
+  /* Digits (ND) */
+  if (cat == 9) return 1;
+  /* Connector punctuation (Pc, which includes underscore-like chars) */
+  if (cat == 12) return 1;
+  /* Mark characters (combining marks are part of base character) */
+  if (cat >= 6 && cat <= 8) return 1;
+  return 0;
+}
+
+/* Enhanced word delimiter check using utf8proc for Unicode support */
+static int isworddelimiter_utf8 (unsigned char c1, unsigned char c2, unsigned char c3) {
+  if (c1 < 0x80) {
+    /* ASCII case */
+    return (lisspace(c1) || (!lislalnum(c1) && c1 != '_'));
+  }
+  
+  /* Multi-byte UTF-8 sequence */
+  unsigned char bytes[4] = {c1, c2, c3, 0};
+  utf8proc_int32_t codepoint = utf8_to_codepoint(bytes, 3);
+  
+  if (codepoint < 0)
+    return 1;  /* Invalid UTF-8 treated as separator */
+  
+  /* Check Unicode category: separators (Zs, Zl, Zp) or non-word chars */
+  utf8proc_category_t cat = utf8proc_category(codepoint);
+  
+  /* Separators: Zs (23), Zl (24), Zp (25) */
+  if (cat == 23 || cat == 24 || cat == 25)
+    return 1;
+  
+  /* Punctuation except Pc: Pd, Ps, Pe, Pi, Pf, Po */
+  if ((cat >= 13 && cat <= 17) || cat == 11)  /* Pd, Ps, Pe, Pi, Pf, Po */
+    return 1;
+  
+  /* Word characters: letters, digits, marks, Pc */
+  if (utf8_is_word_char(codepoint))
+    return 0;
+  
+  return 1;  /* Everything else is a separator */
+}
+
 static int isworddelimiter (int c) {
   if (c == EOZ) return 1;
   if (lisspace(c)) return 1;
   if ((unsigned char)c >= 0x80) return 0;
   return !lislalnum(c) && c != '_';
-}
-
-static int isutf8separator (unsigned char c1, unsigned char c2, unsigned char c3) {
-  if (c1 < 0x80)
-    return (lisspace(c1) || (!lislalnum(c1) && c1 != '_'));
-  if (c1 == 0xC2 && c2 == 0xB7)  /* U+00B7 middle dot, kept for identifiers */
-    return 0;
-  return !luai_isutf8alpha(c1, c2, c3);
 }
 
 static void skiponeutf8char (LexState *ls) {
@@ -582,6 +629,14 @@ static void skiponeutf8char (LexState *ls) {
   }
 }
 
+static int isutf8separator (unsigned char c1, unsigned char c2, unsigned char c3) {
+  if (c1 < 0x80)
+    return (lisspace(c1) || (!lislalnum(c1) && c1 != '_'));
+  if (c1 == 0xC2 && c2 == 0xB7)  /* U+00B7 middle dot, kept for identifiers */
+    return 0;
+  return !luai_isutf8alpha(c1, c2, c3);
+}
+
 static int currentisseparator (LexState *ls) {
   unsigned char c1, c2 = 0, c3 = 0;
   if (ls->current == EOZ)
@@ -594,6 +649,47 @@ static int currentisseparator (LexState *ls) {
   if (ls->z->n > 1)
     c3 = cast_uchar(ls->z->p[1]);
   return isutf8separator(c1, c2, c3);
+}
+
+/* Check if byte at position pos in buffer is a word delimiter */
+static int isworddelimiter_at_buffer_pos(const unsigned char *buffer, size_t buflen, size_t pos) {
+  if (pos >= buflen)
+    return 1;
+  unsigned char c1 = buffer[pos];
+  unsigned char c2 = (pos + 1 < buflen) ? buffer[pos + 1] : 0;
+  unsigned char c3 = (pos + 2 < buflen) ? buffer[pos + 2] : 0;
+  return isworddelimiter_utf8(c1, c2, c3);
+}
+
+/* Find the start of a UTF-8 character at or before a buffer position */
+static size_t find_utf8_start(const unsigned char *buffer, size_t pos) {
+  while (pos > 0 && luai_isutf8cont(buffer[pos]))
+    pos--;
+  return pos;
+}
+
+/* Check if byte at buffer position (possibly mid-UTF-8) is a word delimiter */
+static int bufferpos_is_word_delim(const unsigned char *buffer, size_t buflen, size_t pos) {
+  if (pos >= buflen)
+    return 1;
+  size_t start = find_utf8_start(buffer, pos);
+  unsigned char c1 = buffer[start];
+  unsigned char c2 = (start + 1 < buflen) ? buffer[start + 1] : 0;
+  unsigned char c3 = (start + 2 < buflen) ? buffer[start + 2] : 0;
+  return isworddelimiter_utf8(c1, c2, c3);
+}
+
+/* Check if current input position is a word delimiter */
+static int currentpos_is_word_delim(LexState *ls) {
+  unsigned char c1, c2 = 0, c3 = 0;
+  if (ls->current == EOZ)
+    return 1;
+  c1 = (unsigned char)ls->current;
+  if (ls->z->n > 0)
+    c2 = (unsigned char)ls->z->p[0];
+  if (ls->z->n > 1)
+    c3 = (unsigned char)ls->z->p[1];
+  return isworddelimiter_utf8(c1, c2, c3);
 }
 
 static size_t trailingseparatorsize (Mbuffer *b) {
@@ -898,10 +994,11 @@ static void read_cit_string (LexState *ls, SemInfo *seminfo) {
                        ? (sizeof(close_malcit) - 1)
                        : sizeof(close_cxit);
       size_t start = luaZ_bufflen(ls->buff) - close_len;
-      int has_before = (start > 0);
-      int before = has_before ? (unsigned char)luaZ_buffer(ls->buff)[start - 1] : ' ';
+      int before_is_delim = (start == 0) ? 1 : bufferpos_is_word_delim(
+          cast(unsigned char *, luaZ_buffer(ls->buff)), luaZ_bufflen(ls->buff), start - 1);
+      int current_is_delim = currentpos_is_word_delim(ls);
 
-      if (isworddelimiter(before) && isworddelimiter(ls->current)) {
+      if (before_is_delim && current_is_delim) {
         size_t sepbytes;
         luaZ_buffremove(ls->buff, close_len);
         if (!protect_trailing_sep) {

--- a/fontaro/llex.c
+++ b/fontaro/llex.c
@@ -554,7 +554,7 @@ static void read_string (LexState *ls, int del, SemInfo *seminfo) {
 }
 
 /* Helper to decode UTF-8 sequence to codepoint */
-static utf8proc_int32_t utf8_to_codepoint(const unsigned char *str, size_t len) {
+static utf8proc_int32_t utf8tocodepoint(const unsigned char *str, size_t len) {
   utf8proc_int32_t codepoint;
   utf8proc_ssize_t nread;
   if (len == 0) return -1;
@@ -565,7 +565,7 @@ static utf8proc_int32_t utf8_to_codepoint(const unsigned char *str, size_t len) 
 }
 
 /* Check if a Unicode codepoint is a word character (letter, digit, connector) */
-static int utf8_is_word_char(utf8proc_int32_t codepoint) {
+static int utf8iswordchar(utf8proc_int32_t codepoint) {
   utf8proc_category_t cat = utf8proc_category(codepoint);
   /* Letters (L*): LU, LL, LT, LM, LO */
   if (cat >= 1 && cat <= 5) return 1;
@@ -579,7 +579,7 @@ static int utf8_is_word_char(utf8proc_int32_t codepoint) {
 }
 
 /* Enhanced word delimiter check using utf8proc for Unicode support */
-static int isworddelimiter_utf8 (unsigned char c1, unsigned char c2, unsigned char c3) {
+static int isworddelimiterutf8 (unsigned char c1, unsigned char c2, unsigned char c3) {
   if (c1 < 0x80) {
     /* ASCII case */
     return (lisspace(c1) || (!lislalnum(c1) && c1 != '_'));
@@ -590,7 +590,7 @@ static int isworddelimiter_utf8 (unsigned char c1, unsigned char c2, unsigned ch
 
   /* Multi-byte UTF-8 sequence */
   unsigned char bytes[4] = {c1, c2, c3, 0};
-  utf8proc_int32_t codepoint = utf8_to_codepoint(bytes, 3);
+  utf8proc_int32_t codepoint = utf8tocodepoint(bytes, 3);
 
   if (codepoint < 0)
     return 1;  /* Invalid UTF-8 treated as separator */
@@ -609,7 +609,7 @@ static int isworddelimiter_utf8 (unsigned char c1, unsigned char c2, unsigned ch
     return 1;
 
   /* Word characters: letters, digits, marks, Pc */
-  if (utf8_is_word_char(codepoint))
+  if (utf8iswordchar(codepoint))
     return 0;
 
   return 1;  /* Everything else is a separator */
@@ -631,7 +631,7 @@ static void skiponeutf8char (LexState *ls) {
 }
 
 static int isutf8separator (unsigned char c1, unsigned char c2, unsigned char c3) {
-  return isworddelimiter_utf8(c1, c2, c3);
+  return isworddelimiterutf8(c1, c2, c3);
 }
 
 static int currentisseparator (LexState *ls) {
@@ -656,18 +656,18 @@ static size_t find_utf8_start(const unsigned char *buffer, size_t pos) {
 }
 
 /* Check if byte at buffer position (possibly mid-UTF-8) is a word delimiter */
-static int bufferpos_is_word_delim(const unsigned char *buffer, size_t buflen, size_t pos) {
+static int bufferposisworddelim(const unsigned char *buffer, size_t buflen, size_t pos) {
   if (pos >= buflen)
     return 1;
   size_t start = find_utf8_start(buffer, pos);
   unsigned char c1 = buffer[start];
   unsigned char c2 = (start + 1 < buflen) ? buffer[start + 1] : 0;
   unsigned char c3 = (start + 2 < buflen) ? buffer[start + 2] : 0;
-  return isworddelimiter_utf8(c1, c2, c3);
+  return isworddelimiterutf8(c1, c2, c3);
 }
 
 /* Check if current input position is a word delimiter */
-static int currentpos_is_word_delim(LexState *ls) {
+static int currentposisworddelim(LexState *ls) {
   unsigned char c1, c2 = 0, c3 = 0;
   if (ls->current == EOZ)
     return 1;
@@ -676,7 +676,7 @@ static int currentpos_is_word_delim(LexState *ls) {
     c2 = (unsigned char)ls->z->p[0];
   if (ls->z->n > 1)
     c3 = (unsigned char)ls->z->p[1];
-  return isworddelimiter_utf8(c1, c2, c3);
+  return isworddelimiterutf8(c1, c2, c3);
 }
 
 static size_t trailingseparatorsize (Mbuffer *b) {
@@ -981,9 +981,9 @@ static void read_cit_string (LexState *ls, SemInfo *seminfo) {
                        ? (sizeof(close_malcit) - 1)
                        : sizeof(close_cxit);
       size_t start = luaZ_bufflen(ls->buff) - close_len;
-      int before_is_delim = (start == 0) ? 1 : bufferpos_is_word_delim(
+      int before_is_delim = (start == 0) ? 1 : bufferposisworddelim(
           cast(unsigned char *, luaZ_buffer(ls->buff)), luaZ_bufflen(ls->buff), start - 1);
-      int current_is_delim = currentpos_is_word_delim(ls);
+      int current_is_delim = currentposisworddelim(ls);
 
       if (before_is_delim && current_is_delim) {
         size_t sepbytes;
@@ -1031,12 +1031,12 @@ static int isidentifiercont(LexState *ls) {
   bytes[1] = c2;
   bytes[2] = c3;
   bytes[3] = 0;
-  codepoint = utf8_to_codepoint(bytes, 3);
+  codepoint = utf8tocodepoint(bytes, 3);
   if (codepoint < 0)
     return 0;
   if (codepoint == 0x02C7)  /* U+02C7 CARON is not an identifier continuation */
     return 0;
-  return utf8_is_word_char(codepoint);
+  return utf8iswordchar(codepoint);
 }
 
 static void saveutf8seq(LexState *ls) {

--- a/fontaro/llex.c
+++ b/fontaro/llex.c
@@ -596,8 +596,8 @@ static int isworddelimiter_utf8 (unsigned char c1, unsigned char c2, unsigned ch
   if (cat == 23 || cat == 24 || cat == 25)
     return 1;
   
-  /* Punctuation except Pc: Pd, Ps, Pe, Pi, Pf, Po */
-  if ((cat >= 13 && cat <= 17) || cat == 11)  /* Pd, Ps, Pe, Pi, Pf, Po */
+  /* Punctuation and symbols: Pd (13), Ps (14), Pe (15), Pi (16), Pf (17), Po (11), Sm (19), Sc (20), Sk (21), So (22) */
+  if ((cat >= 13 && cat <= 17) || cat == 11 || (cat >= 19 && cat <= 22))
     return 1;
   
   /* Word characters: letters, digits, marks, Pc */
@@ -605,13 +605,6 @@ static int isworddelimiter_utf8 (unsigned char c1, unsigned char c2, unsigned ch
     return 0;
   
   return 1;  /* Everything else is a separator */
-}
-
-static int isworddelimiter (int c) {
-  if (c == EOZ) return 1;
-  if (lisspace(c)) return 1;
-  if ((unsigned char)c >= 0x80) return 0;
-  return !lislalnum(c) && c != '_';
 }
 
 static void skiponeutf8char (LexState *ls) {
@@ -649,16 +642,6 @@ static int currentisseparator (LexState *ls) {
   if (ls->z->n > 1)
     c3 = cast_uchar(ls->z->p[1]);
   return isutf8separator(c1, c2, c3);
-}
-
-/* Check if byte at position pos in buffer is a word delimiter */
-static int isworddelimiter_at_buffer_pos(const unsigned char *buffer, size_t buflen, size_t pos) {
-  if (pos >= buflen)
-    return 1;
-  unsigned char c1 = buffer[pos];
-  unsigned char c2 = (pos + 1 < buflen) ? buffer[pos + 1] : 0;
-  unsigned char c3 = (pos + 2 < buflen) ? buffer[pos + 2] : 0;
-  return isworddelimiter_utf8(c1, c2, c3);
 }
 
 /* Find the start of a UTF-8 character at or before a buffer position */

--- a/fontaro/lua.c
+++ b/fontaro/lua.c
@@ -400,7 +400,7 @@ static void l_print (lua_State *L) {
 ** Do the LoTPoCIo: repeatedly read (load) a line, evaluate (call) it, and
 ** print any results.
 */
-static void doLoTPoCIo (lua_State *L) {
+static void LoTPoCIurgu (lua_State *L) {
   int status;
   const char *oldprogname = progname;
   progname = NULL;  /* no 'progname' on errors in interactive mode */
@@ -577,11 +577,11 @@ static int pmain (lua_State *L) {
       handle_script(L, argv + script) != LUA_OK)
     return 0;
   if (args & has_i)  /* -i option? */
-    doLoTPoCIo(L);  /* do lego-takso-printo-ciklo */
+    LoTPoCIurgu(L);  /* do lego-takso-printo-ciklo */
   else if (script == argc && !(args & (has_e | has_v))) {  /* no arguments? */
     if (lua_stdin_is_tty()) {  /* running in interactive mode? */
       print_version();
-      doLoTPoCIo(L);  /* do lego-takso-printo-ciklo */
+      LoTPoCIurgu(L);  /* do lego-takso-printo-ciklo */
     }
     else dofile(L, NULL);  /* executes stdin as a file */
   }

--- a/fontaro/lua.c
+++ b/fontaro/lua.c
@@ -397,10 +397,10 @@ static void l_print (lua_State *L) {
 
 
 /*
-** Do the REPL: repeatedly read (load) a line, evaluate (call) it, and
+** Do the LoTPoCIo: repeatedly read (load) a line, evaluate (call) it, and
 ** print any results.
 */
-static void doREPL (lua_State *L) {
+static void doLoTPoCIo (lua_State *L) {
   int status;
   const char *oldprogname = progname;
   progname = NULL;  /* no 'progname' on errors in interactive mode */
@@ -577,11 +577,11 @@ static int pmain (lua_State *L) {
       handle_script(L, argv + script) != LUA_OK)
     return 0;
   if (args & has_i)  /* -i option? */
-    doREPL(L);  /* do read-eval-print loop */
+    doLoTPoCIo(L);  /* do lego-takso-printo-ciklo */
   else if (script == argc && !(args & (has_e | has_v))) {  /* no arguments? */
     if (lua_stdin_is_tty()) {  /* running in interactive mode? */
       print_version();
-      doREPL(L);  /* do read-eval-print loop */
+      doLoTPoCIo(L);  /* do lego-takso-printo-ciklo */
     }
     else dofile(L, NULL);  /* executes stdin as a file */
   }
@@ -606,4 +606,3 @@ int main (int argc, char **argv) {
   lua_close(L);
   return (result && status == LUA_OK) ? EXIT_SUCCESS : EXIT_FAILURE;
 }
-

--- a/testaro/cit-kazoj.lupa
+++ b/testaro/cit-kazoj.lupa
@@ -84,6 +84,57 @@ postuli(f() == "b", "ĥaŭb")
 f = asertu(ŝargu("reŝalte cit ĥaŭĥaŭ ĉit"))
 postuli(f() == "ĥaŭ", "ĥaŭĥaŭ")
 
+-- En cit, '\' ne havas specialan signifon.
+f = asertu(ŝargu("reŝalte cit \\n ĉit"))
+postuli(f() == "\\n", "cit ne interpretu backslash-eskapojn")
+
+-- ĥaĵ-eskapo: speciala interpreto de sekvaj signoj.
+f = asertu(ŝargu("reŝalte cit ĥaĵnĉit"))
+postuli(f() == "\n", "ĥaĵn")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-n-ĉit"))
+postuli(f() == "\n", "ĥaĵe-n-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-novlinie-ĉit"))
+postuli(f() == "\n", "ĥaĵe-novlinie-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-x-7B- ĉit"))
+postuli(f() == "{", "ĥaĵe-x-7B-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵx7B ĉit"))
+postuli(f() == "{", "ĥaĵx7B")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-deksesume-7B- ĉit"))
+postuli(f() == "{", "ĥaĵe-deksesume-7B-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-dekume-123- ĉit"))
+postuli(f() == "{", "ĥaĵe-dekume-123-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-u-263A- ĉit"))
+postuli(f() == "☺", "ĥaĵe-u-263A-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-unikodpunkte-263A- ĉit"))
+postuli(f() == "☺", "ĥaĵe-unikodpunkte-263A-")
+
+f = asertu(ŝargu("reŝalte cit finoĥaĵe-spacglute-\n \tage ĉit"))
+postuli(f() == "finoage", "ĥaĵe-spacglute-")
+
+f = asertu(ŝargu("reŝalte cit finiĥaĵz\n \te ĉit"))
+postuli(f() == "finie", "ĥaĵz")
+
+-- Nevalidaj ĥaĵ-komandoj devas fiaski.
+loke nevalida, eraro4 = ŝargu("reŝalte cit ĥaĵe-nekonata-ĉit")
+postuli(nevalida == nil kaj enhavas(eraro4 aŭ "", "invalid escape sequence"),
+        "nevalida ĥaĵ-subkomando")
+
+loke nevalida2, eraro5 = ŝargu("reŝalte cit ĥaĵe-111-ĉit")
+postuli(nevalida2 == nil kaj enhavas(eraro5 aŭ "", "invalid escape sequence"),
+        "cifera subkomando ne permesata")
+
+loke nevalida3, eraro6 = ŝargu("reŝalte cit ĥaĵe-x-7-ĉit")
+postuli(nevalida3 == nil kaj enhavas(eraro6 aŭ "", "invalid escape sequence"),
+        "nekompleta deksesuma parametro")
+
 se misoj > 0 tiam
   printe("MISE " .. misoj .. " testo(j) en cit-kazoj.lupa")
   os.exit(1)

--- a/testaro/cit-kazoj.lupa
+++ b/testaro/cit-kazoj.lupa
@@ -15,31 +15,31 @@ loke funkcie enhavas(teksto, parto)
 hop
 
 -- 1) Unua blanksigno post cit: neniu/tabo/novlinio.
-loke f = asertu(ŝargu("reŝalte cit,saluton malcit"))
-postuli(f() == "saluton", "cit sen blanko")
+loke fakto iĝe asertu(ŝargu("reŝalte cit,saluton malcit"))
+postuli(fakto() == "saluton", "cit sen blanko")
 
-f = asertu(ŝargu("reŝalte cit¡saluton!ĉit"))
-postuli(f() == "saluton", "cit kun ne-ASCII interpunkcio")
+fakto iĝe asertu(ŝargu("reŝalte cit¡saluton!ĉit"))
+postuli(fakto() == "saluton", "cit kun ne-ASCII interpunkcio")
 
-f = asertu(ŝargu("reŝalte cit¡¡saluton!!ĉit"))
-postuli(f() == "¡saluton!", "cit kun duobla ne-ASCII interpunkcio")
+fakto iĝe asertu(ŝargu("reŝalte cit¡¡saluton!!ĉit"))
+postuli(fakto() == "¡saluton!", "cit kun duobla ne-ASCII interpunkcio")
 
-f = asertu(ŝargu("reŝalte cit\tsaluton malcit"))
-postuli(f() == "saluton", "cit kun tabo")
+fakto iĝe asertu(ŝargu("reŝalte cit\tsaluton malcit"))
+postuli(fakto() == "saluton", "cit kun tabo")
 
-f = asertu(ŝargu("reŝalte cit\nsaluton\nĉit"))
-postuli(f() == "saluton\n", "cit kun novlinio")
+fakto iĝe asertu(ŝargu("reŝalte cit\nsaluton\nĉit"))
+postuli(fakto() == "saluton\n", "cit kun novlinio")
 
 -- 2) Delimita konduto kaj Unicode-randoj.
-f = asertu(ŝargu("reŝalte cit xmalcityz malcit"))
-postuli(f() == "xmalcityz", "malcit interne de pli longa vorto ne fermu")
+fakto iĝe asertu(ŝargu("reŝalte cit xmalcityz malcit"))
+postuli(fakto() == "xmalcityz", "malcit interne de pli longa vorto ne fermu")
 
-f = asertu(ŝargu("reŝalte cit abc malcit, 7"))
-loke v1, v2 = f()
+fakto iĝe asertu(ŝargu("reŝalte cit abc malcit, 7"))
+loke v1, v2 = fakto()
 postuli(v1 == "abc" kaj v2 == 7, "interpunkcia signo post fermilo")
 
-f = asertu(ŝargu("reŝalte cit aĉitb ĉit"))
-postuli(f() == "aĉitb", "ĉit interne de vorto ne fermu")
+fakto iĝe asertu(ŝargu("reŝalte cit aĉitb ĉit"))
+postuli(fakto() == "aĉitb", "ĉit interne de vorto ne fermu")
 
 loke funkcie postuli_malplenan_per_separilo(separilo, nomo)
   loke g, e = ŝargu("reŝalte cit" .. separilo .. "ĉit")
@@ -68,14 +68,14 @@ postuli_malplenan_per_separilo("—", "U+2014 EM DASH (Pd)")
 postuli_malplenan_per_separilo("$", "U+0024 DOLLAR SIGN (Sc)")
 
 -- 2d) Ne-separiloj: identigilaj signoj ne rajtas fermi.
-f = asertu(ŝargu("reŝalte cit a·ĉitb ĉit"))
-postuli(f() == "a·ĉitb", "U+00B7 middle dot restu ne-separilo")
+fakto iĝe asertu(ŝargu("reŝalte cit a·ĉitb ĉit"))
+postuli(fakto() == "a·ĉitb", "U+00B7 middle dot restu ne-separilo")
 
-f = asertu(ŝargu("reŝalte cit a‿ĉitb ĉit"))
-postuli(f() == "a‿ĉitb", "U+203F undertie (Pc) restu ne-separilo")
+fakto iĝe asertu(ŝargu("reŝalte cit a‿ĉitb ĉit"))
+postuli(fakto() == "a‿ĉitb", "U+203F undertie (Pc) restu ne-separilo")
 
-f = asertu(ŝargu("reŝalte cit áĉitb ĉit"))
-postuli(f() == "áĉitb", "U+0301 combining acute (Mn) restu ne-separilo")
+fakto iĝe asertu(ŝargu("reŝalte cit áĉitb ĉit"))
+postuli(fakto() == "áĉitb", "U+0301 combining acute (Mn) restu ne-separilo")
 
 -- 3) Nefinita literalo kaj lini-indiko.
 loke nefinita, eraro = ŝargu("reŝalte cit abc")
@@ -86,21 +86,21 @@ loke nefinita2, eraro2 = ŝargu("\nreŝalte cit abc")
 postuli(nefinita2 == nil kaj enhavas(eraro2 aŭ "", "line 2"), "lini-indiko sur dua linio")
 
 -- 4) Malplena literalo.
-f = asertu(ŝargu("reŝalte cit malcit"))
-postuli(f() == "", "malplena cit ... malcit")
+fakto iĝe asertu(ŝargu("reŝalte cit malcit"))
+postuli(fakto() == "", "malplena cit ... malcit")
 
-f = asertu(ŝargu("reŝalte cit\nĉit"))
-postuli(f() == "", "malplena cit ... ĉit")
+fakto iĝe asertu(ŝargu("reŝalte cit\nĉit"))
+postuli(fakto() == "", "malplena cit ... ĉit")
 
 -- 5) Miksitaj fermiloj.
-f = asertu(ŝargu("reŝalte cit unu malcit"))
-postuli(f() == "unu", "fermilo malcit")
+fakto iĝe asertu(ŝargu("reŝalte cit unu malcit"))
+postuli(fakto() == "unu", "fermilo malcit")
 
-f = asertu(ŝargu("reŝalte cit du ĉit"))
-postuli(f() == "du", "fermilo ĉit")
+fakto iĝe asertu(ŝargu("reŝalte cit du ĉit"))
+postuli(fakto() == "du", "fermilo ĉit")
 
-f = asertu(ŝargu("reŝalte cit\nlinio1\nlinio2\nmalcit"))
-postuli(f() == "linio1\nlinio2\n", "plurlinia fermo per malcit")
+fakto iĝe asertu(ŝargu("reŝalte cit\nlinio1\nlinio2\nmalcit"))
+postuli(fakto() == "linio1\nlinio2\n", "plurlinia fermo per malcit")
 
 -- 6) Negativa ne-interfero: 'cit' ne plu uzeblas kiel ordinara identigilo.
 loke identigilo, eraro3 = ŝargu("loka cit = 0")
@@ -108,79 +108,79 @@ postuli(identigilo == nil kaj enhavas(eraro3 aŭ "", "unfinished cit string"),
         "cit kiel identigilo devas fiaski")
 
 -- Ĥaŭ-eskapo: la sekva signo estas laŭvorta.
-f = asertu(ŝargu("reŝalte cit ĥaŭmalcit malcit"))
-postuli(f() == "malcit", "ĥaŭmalcit")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥaŭmalcit malcit"))
+postuli(fakto() == "malcit", "ĥaŭmalcit")
 
-f = asertu(ŝargu("reŝalte cit ĥaŭĉit ĉit"))
-postuli(f() == "ĉit", "ĥaŭĉit")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥaŭĉit ĉit"))
+postuli(fakto() == "ĉit", "ĥaŭĉit")
 
-f = asertu(ŝargu("reŝalte cit ĥaŭb ĉit"))
-postuli(f() == "b", "ĥaŭb")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥaŭb ĉit"))
+postuli(fakto() == "b", "ĥaŭb")
 
-f = asertu(ŝargu("reŝalte cit ĥaŭĥaŭ ĉit"))
-postuli(f() == "ĥaŭ", "ĥaŭĥaŭ")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥaŭĥaŭ ĉit"))
+postuli(fakto() == "ĥaŭ", "ĥaŭĥaŭ")
 
 -- En cit, '\' ne havas specialan signifon.
-f = asertu(ŝargu("reŝalte cit \\n ĉit"))
-postuli(f() == "\\n", "cit ne interpretu backslash-eskapojn")
+fakto iĝe asertu(ŝargu("reŝalte cit \\n ĉit"))
+postuli(fakto() == "\\n", "cit ne interpretu backslash-eskapojn")
 
 -- ĥap-eskapo: speciala interpreto de sekvaj signoj.
-f = asertu(ŝargu("reŝalte cit ĥape-n-ĉit"))
-postuli(f() == "\n", "ĥape-n-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-n-ĉit"))
+postuli(fakto() == "\n", "ĥape-n-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-novlinie-ĉit"))
-postuli(f() == "\n", "ĥape-novlinie-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-novlinie-ĉit"))
+postuli(fakto() == "\n", "ĥape-novlinie-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-alarme-X ĉit"))
-postuli(f() == "\aX", "ĥape-alarme-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-alarme-X ĉit"))
+postuli(fakto() == "\aX", "ĥape-alarme-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-retropaŝe-X ĉit"))
-postuli(f() == "\bX", "ĥape-retropaŝe-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-retropaŝe-X ĉit"))
+postuli(fakto() == "\bX", "ĥape-retropaŝe-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-paĝosalte-X ĉit"))
-postuli(f() == "\fX", "ĥape-paĝosalte-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-paĝosalte-X ĉit"))
+postuli(fakto() == "\fX", "ĥape-paĝosalte-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-ĉaretrevene-ĉit"))
-postuli(f() == "\r", "ĥape-ĉaretrevene-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-ĉaretrevene-ĉit"))
+postuli(fakto() == "\r", "ĥape-ĉaretrevene-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-tabe-X ĉit"))
-postuli(f() == "\tX", "ĥape-tabe-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-tabe-X ĉit"))
+postuli(fakto() == "\tX", "ĥape-tabe-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-vertikalatabe-X ĉit"))
-postuli(f() == "\vX", "ĥape-vertikalatabe-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-vertikalatabe-X ĉit"))
+postuli(fakto() == "\vX", "ĥape-vertikalatabe-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-x-7B- ĉit"))
-postuli(f() == "{", "ĥape-x-7B-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-x-7B- ĉit"))
+postuli(fakto() == "{", "ĥape-x-7B-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-deksesume-7B- ĉit"))
-postuli(f() == "{", "ĥape-deksesume-7B-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-deksesume-7B- ĉit"))
+postuli(fakto() == "{", "ĥape-deksesume-7B-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-dekume-123- ĉit"))
-postuli(f() == "{", "ĥape-dekume-123-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-dekume-123- ĉit"))
+postuli(fakto() == "{", "ĥape-dekume-123-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-u-263A- ĉit"))
-postuli(f() == "☺", "ĥape-u-263A-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-u-263A- ĉit"))
+postuli(fakto() == "☺", "ĥape-u-263A-")
 
-f = asertu(ŝargu("reŝalte cit ĥape-unikodpunkte-263A- ĉit"))
-postuli(f() == "☺", "ĥape-unikodpunkte-263A-")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥape-unikodpunkte-263A- ĉit"))
+postuli(fakto() == "☺", "ĥape-unikodpunkte-263A-")
 
-f = asertu(ŝargu("reŝalte cit ĥapunikodpunkte-263A ĉit"))
-postuli(f() == "☺", "ĥapunikodpunkte-263A")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥapunikodpunkte-263A ĉit"))
+postuli(fakto() == "☺", "ĥapunikodpunkte-263A")
 
-f = asertu(ŝargu("reŝalte cit ĥapdeksesume-7B ĉit"))
-postuli(f() == "{", "ĥapdeksesume-7B")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥapdeksesume-7B ĉit"))
+postuli(fakto() == "{", "ĥapdeksesume-7B")
 
-f = asertu(ŝargu("reŝalte cit ĥapdekume-123 ĉit"))
-postuli(f() == "{", "ĥapdekume-123")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥapdekume-123 ĉit"))
+postuli(fakto() == "{", "ĥapdekume-123")
 
-f = asertu(ŝargu("reŝalte cit finoĥape-spacglute-\n \tage ĉit"))
-postuli(f() == "finoage", "ĥape-spacglute-")
+fakto iĝe asertu(ŝargu("reŝalte cit finoĥape-spacglute-\n \tage ĉit"))
+postuli(fakto() == "finoage", "ĥape-spacglute-")
 
-f = asertu(ŝargu("reŝalte cit finiĥape-z-\n \te ĉit"))
-postuli(f() == "finie", "ĥape-z-")
+fakto iĝe asertu(ŝargu("reŝalte cit finiĥape-z-\n \te ĉit"))
+postuli(fakto() == "finie", "ĥape-z-")
 
-f = asertu(ŝargu("reŝalte cit finiĥapspacglute\n \te ĉit"))
-postuli(f() == "finie", "ĥapspacglute")
+fakto iĝe asertu(ŝargu("reŝalte cit finiĥapspacglute\n \te ĉit"))
+postuli(fakto() == "finie", "ĥapspacglute")
 
 -- Nevalidaj ĥap-komandoj devas fiaski.
 loke nevalida, eraro4 = ŝargu("reŝalte cit ĥape-nekonata-ĉit")
@@ -236,17 +236,17 @@ postuli(nevalida13 == nil kaj enhavas(eraro16 aŭ "", "invalid escape sequence")
         "rekta mallonga formo malpermesata (v)")
 
 -- Ĥaŭ permesas laŭvorte reprezenti ankaŭ nevalidajn ĥap-formojn.
-f = asertu(ŝargu("reŝalte cit ĥaŭĥapn ĉit"))
-postuli(f() == "ĥapn", "ĥaŭ + ĥapn laŭvorte")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥaŭĥapn ĉit"))
+postuli(fakto() == "ĥapn", "ĥaŭ + ĥapn laŭvorte")
 
-f = asertu(ŝargu("reŝalte cit ĥaŭĥapu-263A ĉit"))
-postuli(f() == "ĥapu-263A", "ĥaŭ + ĥapu-263A laŭvorte")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥaŭĥapu-263A ĉit"))
+postuli(fakto() == "ĥapu-263A", "ĥaŭ + ĥapu-263A laŭvorte")
 
-f = asertu(ŝargu("reŝalte cit ĥaŭĥapx7B ĉit"))
-postuli(f() == "ĥapx7B", "ĥaŭ + ĥapx7B laŭvorte")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥaŭĥapx7B ĉit"))
+postuli(fakto() == "ĥapx7B", "ĥaŭ + ĥapx7B laŭvorte")
 
-f = asertu(ŝargu("reŝalte cit ĥaŭĥape-u-263A- ĉit"))
-postuli(f() == "ĥape-u-263A-", "ĥaŭ + ĥape-u-263A- laŭvorte")
+fakto iĝe asertu(ŝargu("reŝalte cit ĥaŭĥape-u-263A- ĉit"))
+postuli(fakto() == "ĥape-u-263A-", "ĥaŭ + ĥape-u-263A- laŭvorte")
 
 se misoj > 0 tiam
   printe("MISE " .. misoj .. " testo(j) en cit-kazoj.lupa")

--- a/testaro/cit-kazoj.lupa
+++ b/testaro/cit-kazoj.lupa
@@ -77,6 +77,46 @@ postuli(fakto() == "a‿ĉitb", "U+203F undertie (Pc) restu ne-separilo")
 fakto iĝe asertu(ŝargu("reŝalte cit áĉitb ĉit"))
 postuli(fakto() == "áĉitb", "U+0301 combining acute (Mn) restu ne-separilo")
 
+-- 2e) Astralaj (4-bajtaj) unikodaj kazoj.
+postuli_malplenan_per_separilo("😀", "U+1F600 GRINNING FACE (So, 4-bajta)")
+
+fakto iĝe asertu(ŝargu("reŝalte cit 𐐀ĉitb ĉit"))
+postuli(fakto() == "𐐀ĉitb", "U+10400 DESERET LETTER (Lu, 4-bajta) restu ne-separilo")
+
+-- 2f) Formataj regsignoj (Cf) kiel separiloj.
+postuli_malplenan_per_separilo("‍", "U+200D ZERO WIDTH JOINER (Cf)")
+postuli_malplenan_per_separilo("﻿", "U+FEFF ZERO WIDTH NO-BREAK SPACE/BOM (Cf)")
+
+-- 2g) Normaligaj variantoj (NFC/NFD) ĉe vortlimoj.
+fakto iĝe asertu(ŝargu("reŝalte cit áĉitb ĉit"))
+postuli(fakto() == "áĉitb", "NFC: antaŭkunmetita litero restu ne-separilo")
+
+fakto iĝe asertu(ŝargu("reŝalte cit á ĉit"))
+postuli(fakto() == "á", "NFC: fermilo post apartigilo funkciu")
+
+fakto iĝe asertu(ŝargu("reŝalte cit á ĉit"))
+postuli(fakto() == "á", "NFD: kombina marko kun baza litero restu en rezulto")
+
+-- 2h) Malvalidaj UTF-8 sekvencoj: ne kraŝi dum ŝargo/traktado.
+loke funkcie provi_malvalidan_utf8(malsxargxo, nomo)
+  loke peco = string.char(table.unpack(malsxargxo))
+  loke kodo = "reŝalte cit" .. peco .. "ĉit"
+  loke g, e = ŝargu(kodo)
+  se g tiam
+    loke bone, val = pcall(g)
+    postuli(bone, "malvalida UTF-8 (" .. nomo .. ") ne kreu rulan eraron")
+    se bone tiam
+      postuli(type(val) == "string", "malvalida UTF-8 (" .. nomo .. ") revenu ĉenan rezulton")
+    hop
+  alie
+    postuli(enhavas(e aŭ "", "syntax error"), "malvalida UTF-8 (" .. nomo .. ") donu sintaksan eraron se ne ŝargebla")
+  hop
+hop
+
+provi_malvalidan_utf8({0x80}, "orfa daŭrig-bajto")
+provi_malvalidan_utf8({0xC0, 0x80}, "tro-longa NUL")
+provi_malvalidan_utf8({0xF0, 0x28, 0x8C, 0x28}, "nevalida 4-bajta sekvenco")
+
 -- 3) Nefinita literalo kaj lini-indiko.
 loke nefinita, eraro = ŝargu("reŝalte cit abc")
 postuli(nefinita == nil kaj enhavas(eraro aŭ "", "unfinished cit string"), "EOF antaŭ fermilo")

--- a/testaro/cit-kazoj.lupa
+++ b/testaro/cit-kazoj.lupa
@@ -89,20 +89,32 @@ f = asertu(ŝargu("reŝalte cit \\n ĉit"))
 postuli(f() == "\\n", "cit ne interpretu backslash-eskapojn")
 
 -- ĥaĵ-eskapo: speciala interpreto de sekvaj signoj.
-f = asertu(ŝargu("reŝalte cit ĥaĵnĉit"))
-postuli(f() == "\n", "ĥaĵn")
-
 f = asertu(ŝargu("reŝalte cit ĥaĵe-n-ĉit"))
 postuli(f() == "\n", "ĥaĵe-n-")
 
 f = asertu(ŝargu("reŝalte cit ĥaĵe-novlinie-ĉit"))
 postuli(f() == "\n", "ĥaĵe-novlinie-")
 
+f = asertu(ŝargu("reŝalte cit ĥaĵe-alarme-X ĉit"))
+postuli(f() == "\aX", "ĥaĵe-alarme-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-retropaŝe-X ĉit"))
+postuli(f() == "\bX", "ĥaĵe-retropaŝe-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-paĝosalte-X ĉit"))
+postuli(f() == "\fX", "ĥaĵe-paĝosalte-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-ĉaretrevene-ĉit"))
+postuli(f() == "\r", "ĥaĵe-ĉaretrevene-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-tabe-X ĉit"))
+postuli(f() == "\tX", "ĥaĵe-tabe-")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵe-vertikalatabe-X ĉit"))
+postuli(f() == "\vX", "ĥaĵe-vertikalatabe-")
+
 f = asertu(ŝargu("reŝalte cit ĥaĵe-x-7B- ĉit"))
 postuli(f() == "{", "ĥaĵe-x-7B-")
-
-f = asertu(ŝargu("reŝalte cit ĥaĵx7B ĉit"))
-postuli(f() == "{", "ĥaĵx7B")
 
 f = asertu(ŝargu("reŝalte cit ĥaĵe-deksesume-7B- ĉit"))
 postuli(f() == "{", "ĥaĵe-deksesume-7B-")
@@ -116,11 +128,23 @@ postuli(f() == "☺", "ĥaĵe-u-263A-")
 f = asertu(ŝargu("reŝalte cit ĥaĵe-unikodpunkte-263A- ĉit"))
 postuli(f() == "☺", "ĥaĵe-unikodpunkte-263A-")
 
+f = asertu(ŝargu("reŝalte cit ĥaĵunikodpunkte-263A ĉit"))
+postuli(f() == "☺", "ĥaĵunikodpunkte-263A")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵdeksesume-7B ĉit"))
+postuli(f() == "{", "ĥaĵdeksesume-7B")
+
+f = asertu(ŝargu("reŝalte cit ĥaĵdekume-123 ĉit"))
+postuli(f() == "{", "ĥaĵdekume-123")
+
 f = asertu(ŝargu("reŝalte cit finoĥaĵe-spacglute-\n \tage ĉit"))
 postuli(f() == "finoage", "ĥaĵe-spacglute-")
 
-f = asertu(ŝargu("reŝalte cit finiĥaĵz\n \te ĉit"))
-postuli(f() == "finie", "ĥaĵz")
+f = asertu(ŝargu("reŝalte cit finiĥaĵe-z-\n \te ĉit"))
+postuli(f() == "finie", "ĥaĵe-z-")
+
+f = asertu(ŝargu("reŝalte cit finiĥaĵspacglute\n \te ĉit"))
+postuli(f() == "finie", "ĥaĵspacglute")
 
 -- Nevalidaj ĥaĵ-komandoj devas fiaski.
 loke nevalida, eraro4 = ŝargu("reŝalte cit ĥaĵe-nekonata-ĉit")
@@ -134,6 +158,59 @@ postuli(nevalida2 == nil kaj enhavas(eraro5 aŭ "", "invalid escape sequence"),
 loke nevalida3, eraro6 = ŝargu("reŝalte cit ĥaĵe-x-7-ĉit")
 postuli(nevalida3 == nil kaj enhavas(eraro6 aŭ "", "invalid escape sequence"),
         "nekompleta deksesuma parametro")
+
+loke nevalida4, eraro7 = ŝargu("reŝalte cit ĥaĵnĉit")
+postuli(nevalida4 == nil kaj enhavas(eraro7 aŭ "", "invalid escape sequence"),
+        "rekta mallonga formo malpermesata (n)")
+
+loke nevalida5, eraro8 = ŝargu("reŝalte cit ĥaĵx7B ĉit")
+postuli(nevalida5 == nil kaj enhavas(eraro8 aŭ "", "invalid escape sequence"),
+        "rekta mallonga formo malpermesata (x)")
+
+loke nevalida6, eraro9 = ŝargu("reŝalte cit ĥaĵz\n \te ĉit")
+postuli(nevalida6 == nil kaj enhavas(eraro9 aŭ "", "invalid escape sequence"),
+        "rekta mallonga formo malpermesata (z)")
+
+loke nevalida7, eraro10 = ŝargu("reŝalte cit ĥaĵu-263A ĉit")
+postuli(nevalida7 == nil kaj enhavas(eraro10 aŭ "", "invalid escape sequence"),
+        "rekta mallonga formo malpermesata (u)")
+
+loke nevalida8, eraro11 = ŝargu("reŝalte cit ĥaĵaĉit")
+postuli(nevalida8 == nil kaj enhavas(eraro11 aŭ "", "invalid escape sequence"),
+        "rekta mallonga formo malpermesata (a)")
+
+loke nevalida9, eraro12 = ŝargu("reŝalte cit ĥaĵbĉit")
+postuli(nevalida9 == nil kaj enhavas(eraro12 aŭ "", "invalid escape sequence"),
+        "rekta mallonga formo malpermesata (b)")
+
+loke nevalida10, eraro13 = ŝargu("reŝalte cit ĥaĵfĉit")
+postuli(nevalida10 == nil kaj enhavas(eraro13 aŭ "", "invalid escape sequence"),
+        "rekta mallonga formo malpermesata (f)")
+
+loke nevalida11, eraro14 = ŝargu("reŝalte cit ĥaĵrĉit")
+postuli(nevalida11 == nil kaj enhavas(eraro14 aŭ "", "invalid escape sequence"),
+        "rekta mallonga formo malpermesata (r)")
+
+loke nevalida12, eraro15 = ŝargu("reŝalte cit ĥaĵtĉit")
+postuli(nevalida12 == nil kaj enhavas(eraro15 aŭ "", "invalid escape sequence"),
+        "rekta mallonga formo malpermesata (t)")
+
+loke nevalida13, eraro16 = ŝargu("reŝalte cit ĥaĵvĉit")
+postuli(nevalida13 == nil kaj enhavas(eraro16 aŭ "", "invalid escape sequence"),
+        "rekta mallonga formo malpermesata (v)")
+
+-- Ĥaŭ permesas laŭvorte reprezenti ankaŭ nevalidajn ĥaĵ-formojn.
+f = asertu(ŝargu("reŝalte cit ĥaŭĥaĵn ĉit"))
+postuli(f() == "ĥaĵn", "ĥaŭ + ĥaĵn laŭvorte")
+
+f = asertu(ŝargu("reŝalte cit ĥaŭĥaĵu-263A ĉit"))
+postuli(f() == "ĥaĵu-263A", "ĥaŭ + ĥaĵu-263A laŭvorte")
+
+f = asertu(ŝargu("reŝalte cit ĥaŭĥaĵx7B ĉit"))
+postuli(f() == "ĥaĵx7B", "ĥaŭ + ĥaĵx7B laŭvorte")
+
+f = asertu(ŝargu("reŝalte cit ĥaŭĥaĵe-u-263A- ĉit"))
+postuli(f() == "ĥaĵe-u-263A-", "ĥaŭ + ĥaĵe-u-263A- laŭvorte")
 
 se misoj > 0 tiam
   printe("MISE " .. misoj .. " testo(j) en cit-kazoj.lupa")

--- a/testaro/cit-kazoj.lupa
+++ b/testaro/cit-kazoj.lupa
@@ -88,129 +88,129 @@ postuli(f() == "ĥaŭ", "ĥaŭĥaŭ")
 f = asertu(ŝargu("reŝalte cit \\n ĉit"))
 postuli(f() == "\\n", "cit ne interpretu backslash-eskapojn")
 
--- ĥaĵ-eskapo: speciala interpreto de sekvaj signoj.
-f = asertu(ŝargu("reŝalte cit ĥaĵe-n-ĉit"))
-postuli(f() == "\n", "ĥaĵe-n-")
+-- ĥap-eskapo: speciala interpreto de sekvaj signoj.
+f = asertu(ŝargu("reŝalte cit ĥape-n-ĉit"))
+postuli(f() == "\n", "ĥape-n-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-novlinie-ĉit"))
-postuli(f() == "\n", "ĥaĵe-novlinie-")
+f = asertu(ŝargu("reŝalte cit ĥape-novlinie-ĉit"))
+postuli(f() == "\n", "ĥape-novlinie-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-alarme-X ĉit"))
-postuli(f() == "\aX", "ĥaĵe-alarme-")
+f = asertu(ŝargu("reŝalte cit ĥape-alarme-X ĉit"))
+postuli(f() == "\aX", "ĥape-alarme-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-retropaŝe-X ĉit"))
-postuli(f() == "\bX", "ĥaĵe-retropaŝe-")
+f = asertu(ŝargu("reŝalte cit ĥape-retropaŝe-X ĉit"))
+postuli(f() == "\bX", "ĥape-retropaŝe-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-paĝosalte-X ĉit"))
-postuli(f() == "\fX", "ĥaĵe-paĝosalte-")
+f = asertu(ŝargu("reŝalte cit ĥape-paĝosalte-X ĉit"))
+postuli(f() == "\fX", "ĥape-paĝosalte-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-ĉaretrevene-ĉit"))
-postuli(f() == "\r", "ĥaĵe-ĉaretrevene-")
+f = asertu(ŝargu("reŝalte cit ĥape-ĉaretrevene-ĉit"))
+postuli(f() == "\r", "ĥape-ĉaretrevene-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-tabe-X ĉit"))
-postuli(f() == "\tX", "ĥaĵe-tabe-")
+f = asertu(ŝargu("reŝalte cit ĥape-tabe-X ĉit"))
+postuli(f() == "\tX", "ĥape-tabe-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-vertikalatabe-X ĉit"))
-postuli(f() == "\vX", "ĥaĵe-vertikalatabe-")
+f = asertu(ŝargu("reŝalte cit ĥape-vertikalatabe-X ĉit"))
+postuli(f() == "\vX", "ĥape-vertikalatabe-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-x-7B- ĉit"))
-postuli(f() == "{", "ĥaĵe-x-7B-")
+f = asertu(ŝargu("reŝalte cit ĥape-x-7B- ĉit"))
+postuli(f() == "{", "ĥape-x-7B-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-deksesume-7B- ĉit"))
-postuli(f() == "{", "ĥaĵe-deksesume-7B-")
+f = asertu(ŝargu("reŝalte cit ĥape-deksesume-7B- ĉit"))
+postuli(f() == "{", "ĥape-deksesume-7B-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-dekume-123- ĉit"))
-postuli(f() == "{", "ĥaĵe-dekume-123-")
+f = asertu(ŝargu("reŝalte cit ĥape-dekume-123- ĉit"))
+postuli(f() == "{", "ĥape-dekume-123-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-u-263A- ĉit"))
-postuli(f() == "☺", "ĥaĵe-u-263A-")
+f = asertu(ŝargu("reŝalte cit ĥape-u-263A- ĉit"))
+postuli(f() == "☺", "ĥape-u-263A-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵe-unikodpunkte-263A- ĉit"))
-postuli(f() == "☺", "ĥaĵe-unikodpunkte-263A-")
+f = asertu(ŝargu("reŝalte cit ĥape-unikodpunkte-263A- ĉit"))
+postuli(f() == "☺", "ĥape-unikodpunkte-263A-")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵunikodpunkte-263A ĉit"))
-postuli(f() == "☺", "ĥaĵunikodpunkte-263A")
+f = asertu(ŝargu("reŝalte cit ĥapunikodpunkte-263A ĉit"))
+postuli(f() == "☺", "ĥapunikodpunkte-263A")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵdeksesume-7B ĉit"))
-postuli(f() == "{", "ĥaĵdeksesume-7B")
+f = asertu(ŝargu("reŝalte cit ĥapdeksesume-7B ĉit"))
+postuli(f() == "{", "ĥapdeksesume-7B")
 
-f = asertu(ŝargu("reŝalte cit ĥaĵdekume-123 ĉit"))
-postuli(f() == "{", "ĥaĵdekume-123")
+f = asertu(ŝargu("reŝalte cit ĥapdekume-123 ĉit"))
+postuli(f() == "{", "ĥapdekume-123")
 
-f = asertu(ŝargu("reŝalte cit finoĥaĵe-spacglute-\n \tage ĉit"))
-postuli(f() == "finoage", "ĥaĵe-spacglute-")
+f = asertu(ŝargu("reŝalte cit finoĥape-spacglute-\n \tage ĉit"))
+postuli(f() == "finoage", "ĥape-spacglute-")
 
-f = asertu(ŝargu("reŝalte cit finiĥaĵe-z-\n \te ĉit"))
-postuli(f() == "finie", "ĥaĵe-z-")
+f = asertu(ŝargu("reŝalte cit finiĥape-z-\n \te ĉit"))
+postuli(f() == "finie", "ĥape-z-")
 
-f = asertu(ŝargu("reŝalte cit finiĥaĵspacglute\n \te ĉit"))
-postuli(f() == "finie", "ĥaĵspacglute")
+f = asertu(ŝargu("reŝalte cit finiĥapspacglute\n \te ĉit"))
+postuli(f() == "finie", "ĥapspacglute")
 
--- Nevalidaj ĥaĵ-komandoj devas fiaski.
-loke nevalida, eraro4 = ŝargu("reŝalte cit ĥaĵe-nekonata-ĉit")
+-- Nevalidaj ĥap-komandoj devas fiaski.
+loke nevalida, eraro4 = ŝargu("reŝalte cit ĥape-nekonata-ĉit")
 postuli(nevalida == nil kaj enhavas(eraro4 aŭ "", "invalid escape sequence"),
-        "nevalida ĥaĵ-subkomando")
+        "nevalida ĥap-subkomando")
 
-loke nevalida2, eraro5 = ŝargu("reŝalte cit ĥaĵe-111-ĉit")
+loke nevalida2, eraro5 = ŝargu("reŝalte cit ĥape-111-ĉit")
 postuli(nevalida2 == nil kaj enhavas(eraro5 aŭ "", "invalid escape sequence"),
         "cifera subkomando ne permesata")
 
-loke nevalida3, eraro6 = ŝargu("reŝalte cit ĥaĵe-x-7-ĉit")
+loke nevalida3, eraro6 = ŝargu("reŝalte cit ĥape-x-7-ĉit")
 postuli(nevalida3 == nil kaj enhavas(eraro6 aŭ "", "invalid escape sequence"),
         "nekompleta deksesuma parametro")
 
-loke nevalida4, eraro7 = ŝargu("reŝalte cit ĥaĵnĉit")
+loke nevalida4, eraro7 = ŝargu("reŝalte cit ĥapnĉit")
 postuli(nevalida4 == nil kaj enhavas(eraro7 aŭ "", "invalid escape sequence"),
         "rekta mallonga formo malpermesata (n)")
 
-loke nevalida5, eraro8 = ŝargu("reŝalte cit ĥaĵx7B ĉit")
+loke nevalida5, eraro8 = ŝargu("reŝalte cit ĥapx7B ĉit")
 postuli(nevalida5 == nil kaj enhavas(eraro8 aŭ "", "invalid escape sequence"),
         "rekta mallonga formo malpermesata (x)")
 
-loke nevalida6, eraro9 = ŝargu("reŝalte cit ĥaĵz\n \te ĉit")
+loke nevalida6, eraro9 = ŝargu("reŝalte cit ĥapz\n \te ĉit")
 postuli(nevalida6 == nil kaj enhavas(eraro9 aŭ "", "invalid escape sequence"),
         "rekta mallonga formo malpermesata (z)")
 
-loke nevalida7, eraro10 = ŝargu("reŝalte cit ĥaĵu-263A ĉit")
+loke nevalida7, eraro10 = ŝargu("reŝalte cit ĥapu-263A ĉit")
 postuli(nevalida7 == nil kaj enhavas(eraro10 aŭ "", "invalid escape sequence"),
         "rekta mallonga formo malpermesata (u)")
 
-loke nevalida8, eraro11 = ŝargu("reŝalte cit ĥaĵaĉit")
+loke nevalida8, eraro11 = ŝargu("reŝalte cit ĥapaĉit")
 postuli(nevalida8 == nil kaj enhavas(eraro11 aŭ "", "invalid escape sequence"),
         "rekta mallonga formo malpermesata (a)")
 
-loke nevalida9, eraro12 = ŝargu("reŝalte cit ĥaĵbĉit")
+loke nevalida9, eraro12 = ŝargu("reŝalte cit ĥapbĉit")
 postuli(nevalida9 == nil kaj enhavas(eraro12 aŭ "", "invalid escape sequence"),
         "rekta mallonga formo malpermesata (b)")
 
-loke nevalida10, eraro13 = ŝargu("reŝalte cit ĥaĵfĉit")
+loke nevalida10, eraro13 = ŝargu("reŝalte cit ĥapfĉit")
 postuli(nevalida10 == nil kaj enhavas(eraro13 aŭ "", "invalid escape sequence"),
         "rekta mallonga formo malpermesata (f)")
 
-loke nevalida11, eraro14 = ŝargu("reŝalte cit ĥaĵrĉit")
+loke nevalida11, eraro14 = ŝargu("reŝalte cit ĥaprĉit")
 postuli(nevalida11 == nil kaj enhavas(eraro14 aŭ "", "invalid escape sequence"),
         "rekta mallonga formo malpermesata (r)")
 
-loke nevalida12, eraro15 = ŝargu("reŝalte cit ĥaĵtĉit")
+loke nevalida12, eraro15 = ŝargu("reŝalte cit ĥaptĉit")
 postuli(nevalida12 == nil kaj enhavas(eraro15 aŭ "", "invalid escape sequence"),
         "rekta mallonga formo malpermesata (t)")
 
-loke nevalida13, eraro16 = ŝargu("reŝalte cit ĥaĵvĉit")
+loke nevalida13, eraro16 = ŝargu("reŝalte cit ĥapvĉit")
 postuli(nevalida13 == nil kaj enhavas(eraro16 aŭ "", "invalid escape sequence"),
         "rekta mallonga formo malpermesata (v)")
 
--- Ĥaŭ permesas laŭvorte reprezenti ankaŭ nevalidajn ĥaĵ-formojn.
-f = asertu(ŝargu("reŝalte cit ĥaŭĥaĵn ĉit"))
-postuli(f() == "ĥaĵn", "ĥaŭ + ĥaĵn laŭvorte")
+-- Ĥaŭ permesas laŭvorte reprezenti ankaŭ nevalidajn ĥap-formojn.
+f = asertu(ŝargu("reŝalte cit ĥaŭĥapn ĉit"))
+postuli(f() == "ĥapn", "ĥaŭ + ĥapn laŭvorte")
 
-f = asertu(ŝargu("reŝalte cit ĥaŭĥaĵu-263A ĉit"))
-postuli(f() == "ĥaĵu-263A", "ĥaŭ + ĥaĵu-263A laŭvorte")
+f = asertu(ŝargu("reŝalte cit ĥaŭĥapu-263A ĉit"))
+postuli(f() == "ĥapu-263A", "ĥaŭ + ĥapu-263A laŭvorte")
 
-f = asertu(ŝargu("reŝalte cit ĥaŭĥaĵx7B ĉit"))
-postuli(f() == "ĥaĵx7B", "ĥaŭ + ĥaĵx7B laŭvorte")
+f = asertu(ŝargu("reŝalte cit ĥaŭĥapx7B ĉit"))
+postuli(f() == "ĥapx7B", "ĥaŭ + ĥapx7B laŭvorte")
 
-f = asertu(ŝargu("reŝalte cit ĥaŭĥaĵe-u-263A- ĉit"))
-postuli(f() == "ĥaĵe-u-263A-", "ĥaŭ + ĥaĵe-u-263A- laŭvorte")
+f = asertu(ŝargu("reŝalte cit ĥaŭĥape-u-263A- ĉit"))
+postuli(f() == "ĥape-u-263A-", "ĥaŭ + ĥape-u-263A- laŭvorte")
 
 se misoj > 0 tiam
   printe("MISE " .. misoj .. " testo(j) en cit-kazoj.lupa")

--- a/testaro/cit-kazoj.lupa
+++ b/testaro/cit-kazoj.lupa
@@ -1,0 +1,92 @@
+#!/usr/bin/env lupe
+-- Regresaj testoj por cit/malcit/ĉit kaj ĥaŭ-eskapo en llex.
+
+loke misoj = 0
+
+loke funkcie postuli(kondiĉo, mesaĝo)
+  se ne kondiĉo tiam
+    printe('[MISE] ' .. mesaĝo)
+    misoj = misoj + 1
+  hop
+hop
+
+loke funkcie enhavas(teksto, parto)
+  reŝalte teksto:find(parto, 1, vera) ~= nil
+hop
+
+-- 1) Unua blanksigno post cit: neniu/tabo/novlinio.
+loke f = asertu(ŝargu("reŝalte cit,saluton malcit"))
+postuli(f() == "saluton", "cit sen blanko")
+
+f = asertu(ŝargu("reŝalte cit¡saluton!ĉit"))
+postuli(f() == "saluton", "cit kun ne-ASCII interpunkcio")
+
+f = asertu(ŝargu("reŝalte cit¡¡saluton!!ĉit"))
+postuli(f() == "¡saluton!", "cit kun duobla ne-ASCII interpunkcio")
+
+f = asertu(ŝargu("reŝalte cit\tsaluton malcit"))
+postuli(f() == "saluton", "cit kun tabo")
+
+f = asertu(ŝargu("reŝalte cit\nsaluton\nĉit"))
+postuli(f() == "saluton\n", "cit kun novlinio")
+
+-- 2) Delimita konduto kaj Unicode-randoj.
+f = asertu(ŝargu("reŝalte cit xmalcityz malcit"))
+postuli(f() == "xmalcityz", "malcit interne de pli longa vorto ne fermu")
+
+f = asertu(ŝargu("reŝalte cit abc malcit, 7"))
+loke v1, v2 = f()
+postuli(v1 == "abc" kaj v2 == 7, "interpunkcia signo post fermilo")
+
+f = asertu(ŝargu("reŝalte cit aĉitb ĉit"))
+postuli(f() == "aĉitb", "ĉit interne de vorto ne fermu")
+
+-- 3) Nefinita literalo kaj lini-indiko.
+loke nefinita, eraro = ŝargu("reŝalte cit abc")
+postuli(nefinita == nil kaj enhavas(eraro aŭ "", "unfinished cit string"), "EOF antaŭ fermilo")
+postuli(enhavas(eraro aŭ "", "line 1"), "lini-indiko por nefinita cit")
+
+loke nefinita2, eraro2 = ŝargu("\nreŝalte cit abc")
+postuli(nefinita2 == nil kaj enhavas(eraro2 aŭ "", "line 2"), "lini-indiko sur dua linio")
+
+-- 4) Malplena literalo.
+f = asertu(ŝargu("reŝalte cit malcit"))
+postuli(f() == "", "malplena cit ... malcit")
+
+f = asertu(ŝargu("reŝalte cit\nĉit"))
+postuli(f() == "", "malplena cit ... ĉit")
+
+-- 5) Miksitaj fermiloj.
+f = asertu(ŝargu("reŝalte cit unu malcit"))
+postuli(f() == "unu", "fermilo malcit")
+
+f = asertu(ŝargu("reŝalte cit du ĉit"))
+postuli(f() == "du", "fermilo ĉit")
+
+f = asertu(ŝargu("reŝalte cit\nlinio1\nlinio2\nmalcit"))
+postuli(f() == "linio1\nlinio2\n", "plurlinia fermo per malcit")
+
+-- 6) Negativa ne-interfero: 'cit' ne plu uzeblas kiel ordinara identigilo.
+loke identigilo, eraro3 = ŝargu("loka cit = 0")
+postuli(identigilo == nil kaj enhavas(eraro3 aŭ "", "unfinished cit string"),
+        "cit kiel identigilo devas fiaski")
+
+-- Ĥaŭ-eskapo: la sekva signo estas laŭvorta.
+f = asertu(ŝargu("reŝalte cit ĥaŭmalcit malcit"))
+postuli(f() == "malcit", "ĥaŭmalcit")
+
+f = asertu(ŝargu("reŝalte cit ĥaŭĉit ĉit"))
+postuli(f() == "ĉit", "ĥaŭĉit")
+
+f = asertu(ŝargu("reŝalte cit ĥaŭb ĉit"))
+postuli(f() == "b", "ĥaŭb")
+
+f = asertu(ŝargu("reŝalte cit ĥaŭĥaŭ ĉit"))
+postuli(f() == "ĥaŭ", "ĥaŭĥaŭ")
+
+se misoj > 0 tiam
+  printe("MISE " .. misoj .. " testo(j) en cit-kazoj.lupa")
+  os.exit(1)
+alie
+  printe("[BONE] cit-kazoj.lupa")
+hop

--- a/testaro/cit-kazoj.lupa
+++ b/testaro/cit-kazoj.lupa
@@ -41,6 +41,42 @@ postuli(v1 == "abc" kaj v2 == 7, "interpunkcia signo post fermilo")
 f = asertu(ŝargu("reŝalte cit aĉitb ĉit"))
 postuli(f() == "aĉitb", "ĉit interne de vorto ne fermu")
 
+loke funkcie postuli_malplenan_per_separilo(separilo, nomo)
+  loke g, e = ŝargu("reŝalte cit" .. separilo .. "ĉit")
+  postuli(g ~= nil, "ne povis ŝargi por separilo " .. nomo .. ": " .. (e aŭ ""))
+  se g tiam
+    postuli(g() == "", "separilo " .. nomo .. " estu valida por malplena cit")
+  hop
+hop
+
+-- 2b) Specifaj unikodaj simboloj devas validi kiel separiloj.
+postuli_malplenan_per_separilo("∅", "U+2205 EMPTY SET")
+postuli_malplenan_per_separilo("⦚", "U+299A VERTICAL ZIGZAG LINE")
+postuli_malplenan_per_separilo("∎", "U+220E END OF PROOF")
+postuli_malplenan_per_separilo("⟂", "U+27C2 PERPENDICULAR")
+postuli_malplenan_per_separilo("ˇ", "U+02C7 CARON")
+postuli_malplenan_per_separilo("∇", "U+2207 NABLA")
+postuli_malplenan_per_separilo("☮", "U+262E PEACE SYMBOL")
+postuli_malplenan_per_separilo("–", "U+2013 EN DASH")
+postuli_malplenan_per_separilo("￤", "U+FFE4 FULLWIDTH BROKEN BAR")
+
+-- 2c) Unicode-kategori-randoj (konataj limkazoj).
+postuli_malplenan_per_separilo(" ", "U+00A0 NO-BREAK SPACE (Zs)")
+postuli_malplenan_per_separilo(" ", "U+202F NARROW NO-BREAK SPACE (Zs)")
+postuli_malplenan_per_separilo("　", "U+3000 IDEOGRAPHIC SPACE (Zs)")
+postuli_malplenan_per_separilo("—", "U+2014 EM DASH (Pd)")
+postuli_malplenan_per_separilo("$", "U+0024 DOLLAR SIGN (Sc)")
+
+-- 2d) Ne-separiloj: identigilaj signoj ne rajtas fermi.
+f = asertu(ŝargu("reŝalte cit a·ĉitb ĉit"))
+postuli(f() == "a·ĉitb", "U+00B7 middle dot restu ne-separilo")
+
+f = asertu(ŝargu("reŝalte cit a‿ĉitb ĉit"))
+postuli(f() == "a‿ĉitb", "U+203F undertie (Pc) restu ne-separilo")
+
+f = asertu(ŝargu("reŝalte cit áĉitb ĉit"))
+postuli(f() == "áĉitb", "U+0301 combining acute (Mn) restu ne-separilo")
+
 -- 3) Nefinita literalo kaj lini-indiko.
 loke nefinita, eraro = ŝargu("reŝalte cit abc")
 postuli(nefinita == nil kaj enhavas(eraro aŭ "", "unfinished cit string"), "EOF antaŭ fermilo")

--- a/testaro/lotpocio-kongruo.sh
+++ b/testaro/lotpocio-kongruo.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+set -eu
+
+if ! command -v lua >/dev/null 2>&1; then
+  echo "[MISE] lotpocio-kongruo.sh: Lua ne disponeblas en PATH"
+  exit 0
+fi
+
+if [ ! -x "./fontaro/lupe" ]; then
+  echo "[MISE] lotpocio-kongruo.sh: mankas ./fontaro/lupe"
+  exit 1
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+matrix_lua="$tmpdir/matrix_lua.lua"
+matrix_cit="$tmpdir/matrix_cit.lua"
+lua_out="$tmpdir/lua.out"
+lupe_out="$tmpdir/lupe.out"
+cit_out="$tmpdir/cit.out"
+cit_expected="$tmpdir/cit.expected"
+
+cat >"$matrix_lua" <<'EOF'
+local cases = {
+  {"raw-empty-quote", "\"\""},
+  {"raw-unfinished-quote", "\""},
+  {"raw-open-long", "[["},
+  {"raw-empty-long", "[[\n]]"},
+  {"raw-text-long", "[[\ntest\n]]"},
+  {"raw-open-eq-long", "[=["},
+  {"raw-empty-eq-long", "[=[\n]=]"},
+  {"return-empty-quote", "return \"\""},
+  {"return-text-long", "return [[test]]"},
+  {"return-text-eq-long", "return [=[test]=]"},
+}
+for _, case in ipairs(cases) do
+  local name, src = case[1], case[2]
+  local fn = load(src, "=(lotpocio)")
+  if not fn then
+    print(name .. "|ERR")
+  else
+    local ok, value = pcall(fn)
+    if ok then
+      print(name .. "|OK|" .. tostring(value))
+    else
+      print(name .. "|RUNERR")
+    end
+  end
+end
+EOF
+
+cat >"$matrix_cit" <<'EOF'
+local cases = {
+  {"cit-open-only", "cit"},
+  {"return-cit-space", "return cit saluton malcit"},
+  {"return-cit-punct", "return cit¡saluton!ĉit"},
+  {"return-cit-double-punct", "return cit¡¡saluton!!ĉit"},
+}
+for _, case in ipairs(cases) do
+  local name, src = case[1], case[2]
+  local fn = load(src, "=(lotpocio)")
+  if not fn then
+    print(name .. "|ERR")
+  else
+    local ok, value = pcall(fn)
+    if ok then
+      print(name .. "|OK|" .. tostring(value))
+    else
+      print(name .. "|RUNERR")
+    end
+  end
+end
+EOF
+
+lua "$matrix_lua" >"$lua_out"
+./fontaro/lupe "$matrix_lua" >"$lupe_out"
+
+if ! diff -u "$lua_out" "$lupe_out" >/dev/null; then
+  echo "[MISE] lotpocio-kongruo.sh: Lua/Lupa malsamas por \"\", [[ ]], [=[ ]=] en LoTPoCIo-similaj enigoj"
+  diff -u "$lua_out" "$lupe_out" || true
+  exit 1
+fi
+
+./fontaro/lupe "$matrix_cit" >"$cit_out"
+cat >"$cit_expected" <<'EOF'
+cit-open-only|ERR
+return-cit-space|OK|saluton
+return-cit-punct|OK|saluton
+return-cit-double-punct|OK|¡saluton!
+EOF
+
+if ! diff -u "$cit_expected" "$cit_out" >/dev/null; then
+  echo "[MISE] lotpocio-kongruo.sh: cit-konduto ne kongruas kun atendataj LoTPoCIo-similaj rezultoj"
+  diff -u "$cit_expected" "$cit_out" || true
+  exit 1
+fi
+
+echo "[BONE] lotpocio-kongruo.sh"

--- a/testaro/sinonimoj-leksilo.lupa
+++ b/testaro/sinonimoj-leksilo.lupa
@@ -136,6 +136,14 @@ loke funkcie ŝlosilvortaro·testi()
   ho ŝparvojo ho
   asertu(aĵo baŭ 2, 'ho/ŝalte MISE')
 
+  ĉi citaĵo iĝu cit saluton malcit
+  asertu(citaĵo baŭ 'saluton', 'cit/malcit MISE')
+  ĉi plurliniaĵo iĝu cit
+linio-unu
+linio-du
+ĉit
+  asertu(plurliniaĵo baŭ 'linio-unu\nlinio-du\n', 'cit/ĉit MISE')
+
   reŝalte vera
 hop
 


### PR DESCRIPTION
## Celo

Ĉi tiu MR efektivigas la citaĵan sintakson `cit ... malcit/ĉit` kun difinita konduto por apartigiloj, fermado, kaj eskapo.

## Ĉefaj ŝanĝoj

- aldonita `cit` kiel longĉena malfermilo;
- aldonitaj `malcit` kaj `ĉit` kiel fermiloj (nur ĉe vortlimoj);
- aldonita `ĥaŭ` por senarmigi la sekvan signon en `cit`-ĉeno;
- plibonigita Unicode-apartigila konduto (inkluzive `cit¡...!ĉit`);
- aldonita dediĉita testdosiero `testaro/cit-kazoj.lupa` por randkazoj;
- aldonita `testaro/lotpocio-kongruo.sh` por Lua/Lupa kongruo de klasikaj citaĵ-formoj en LoTPoCIo-similaj scenaroj;
- enkondukita terminologia dokumento `dokumentaro/ĵargono.md` (LoTPoCIo).

## Noto pri kongruo

`cit` nun estas rezervita de la leksila konduto por malfermi cit-ĉenon; tial `loka cit = 0` intence fiaskas.

Closes #26
